### PR TITLE
`get_universal_calculator()` return ASE calculators as-is

### DIFF
--- a/matcalc/util.py
+++ b/matcalc/util.py
@@ -6,7 +6,12 @@ import functools
 from ase.calculators.calculator import Calculator
 
 # Listing of supported universal calculators.
-UNIVERSAL_CALCULATORS = ("M3GNet-MP-2021.2.8-PES", "M3GNet-MP-2021.2.8-DIRECT-PES", "CHGNet")
+UNIVERSAL_CALCULATORS = (
+    "M3GNet",
+    "M3GNet-MP-2021.2.8-PES",
+    "M3GNet-MP-2021.2.8-DIRECT-PES",
+    "CHGNet",
+)
 
 
 @functools.lru_cache
@@ -21,6 +26,9 @@ def get_universal_calculator(name: str | Calculator, **kwargs) -> Calculator:
     Args:
         name (str): Name of calculator.
         **kwargs: Passthrough to calculator init.
+
+    Raises:
+        ValueError: on unrecognized model name.
 
     Returns:
         Calculator
@@ -43,4 +51,4 @@ def get_universal_calculator(name: str | Calculator, **kwargs) -> Calculator:
 
         return CHGNetCalculator(**kwargs)
 
-    raise ValueError(f"Unsupported {name=}")
+    raise ValueError(f"Unrecognized {name=}, must be one of {UNIVERSAL_CALCULATORS}")

--- a/matcalc/util.py
+++ b/matcalc/util.py
@@ -36,17 +36,17 @@ def get_universal_calculator(name: str | Calculator, **kwargs) -> Calculator:
     if isinstance(name, Calculator):
         return name
 
-    if name in ("M3GNet", "M3GNet-MP-2021.2.8-PES", "M3GNet-MP-2021.2.8-DIRECT-PES"):
+    if name.lower().startswith("m3gnet"):
         import matgl
         from matgl.ext.ase import M3GNetCalculator
 
         # M3GNet is shorthand for latest M3GNet based on DIRECT sampling.
-        name = {"M3GNet": "M3GNet-MP-2021.2.8-PES"}.get(name, name)
+        name = {"m3gnet": "M3GNet-MP-2021.2.8-PES"}.get(name.lower(), name)
         model = matgl.load_model(name)
         kwargs.setdefault("stress_weight", 0.01)
         return M3GNetCalculator(potential=model, **kwargs)
 
-    if name == "CHGNet":
+    if name.lower() == "chgnet":
         from chgnet.model.dynamics import CHGNetCalculator
 
         return CHGNetCalculator(**kwargs)

--- a/matcalc/util.py
+++ b/matcalc/util.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 
 import functools
 
+from ase.calculators.calculator import Calculator
+
 # Listing of supported universal calculators.
 UNIVERSAL_CALCULATORS = ("M3GNet-MP-2021.2.8-PES", "M3GNet-MP-2021.2.8-DIRECT-PES", "CHGNet")
 
 
 @functools.lru_cache
-def get_universal_calculator(name: str, **kwargs):
+def get_universal_calculator(name: str | Calculator, **kwargs) -> Calculator:
     """
     Helper method to get some well-known **universal** calculators.
     Imports should be inside if statements to ensure that all models are optional dependencies.
@@ -23,6 +25,9 @@ def get_universal_calculator(name: str, **kwargs):
     Returns:
         Calculator
     """
+    if isinstance(name, Calculator):
+        return name
+
     if name in ("M3GNet", "M3GNet-MP-2021.2.8-PES", "M3GNet-MP-2021.2.8-DIRECT-PES"):
         import matgl
         from matgl.ext.ase import M3GNetCalculator

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -4,10 +4,13 @@ from matcalc.util import get_universal_calculator, UNIVERSAL_CALCULATORS
 from ase.calculators.calculator import Calculator
 
 
-def test_get_calculator():
+def test_get_universal_calculator():
     for name in UNIVERSAL_CALCULATORS:
         calc = get_universal_calculator(name)
         assert isinstance(calc, Calculator)
+        same_calc = get_universal_calculator(calc)  # test ASE Calculator classes are returned as-is
+        assert calc is same_calc
 
-    with pytest.raises(ValueError, match="Unsupported name='whatever'"):
+    with pytest.raises(ValueError) as exc:
         get_universal_calculator("whatever")
+    assert str(exc.value) == f"Unrecognized name='whatever', must be one of {UNIVERSAL_CALCULATORS}"


### PR DESCRIPTION
37d8b36 `get_universal_calculator()` return ASE calculators as-is
b276dbf list valid options in err msg on unrecognized model name
9c02281 make `get_universal_calculator` less case sensitive
dc3f731 fix `test_get_universal_calculator`