### PR TITLE
Rename EOSCalc return dict keys

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ ci:
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.284
+    rev: v0.0.285
     hooks:
       - id: ruff
         args: [--fix]
@@ -25,7 +25,7 @@ repos:
       - id: black-jupyter
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.5.0
+    rev: v1.5.1
     hooks:
       - id: mypy
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## Introduction
 
-MatCalc is a python library for calculating materials properties from the potential energy surface (PES). The
+MatCalc is a Python library for calculating materials properties from the potential energy surface (PES). The
 PES can be from DFT or, more commonly, from machine learning interatomic potentials (MLIPs).
 
 Calculating various materials properties can require relatively involved setup of various simulation codes. The
@@ -23,8 +23,8 @@ parameterization of the PES.
 
 ## Outline
 
-The main base class in MatCalc is PropCalc (property calculator). All PropCalc subclasses should implement a
-`calc(structure) -> dict` method that takes in a Pymatgen Structure and returns a dict of properties.
+The main base class in MatCalc is `PropCalc` (property calculator). [All `PropCalc` subclasses](https://github.com/search?q=repo%3Amaterialsvirtuallab%2Fmatcalc%20%22(PropCalc)%22) should implement a
+`calc(pymatgen.Structure) -> dict` method that returns a dict of properties.
 
-In general, PropCalc should be initialized with an ML model or ASE calculator, which is then used by either ASE,
+In general, `PropCalc` should be initialized with an ML model or ASE calculator, which is then used by either ASE,
 LAMMPS or some other simulation code to perform calculations of properties.

--- a/matcalc/eos.py
+++ b/matcalc/eos.py
@@ -32,15 +32,13 @@ class EOSCalc(PropCalc):
         """
         Args:
             calculator: ASE Calculator to use.
-            optimizer (str or ase Optimizer): The optimization algorithm. Defaults to "FIRE".
-            steps (int): Max number of steps for relaxation.
-            max_abs_strain (float): The maximum absolute strain applied to the structure. Defaults to 0.1, i.e.,
-                10% strain.
+            optimizer (str | ase Optimizer): The optimization algorithm. Defaults to "FIRE".
+            steps (int): Max number of steps for relaxation. Defaults to 500.
+            max_abs_strain (float): The maximum absolute strain applied to the structure. Defaults to 0.1 (10% strain).
             n_points (int): Number of points in which to compute the EOS. Defaults to 11.
-
             fmax (float): Max force for relaxation (of structure as well as atoms).
             relax_structure: Whether to first relax the structure. Set to False if structures provided are pre-relaxed
-                with the same calculator.
+                with the same calculator. Defaults to True.
         """
         self.calculator = calculator
         self.optimizer = optimizer
@@ -57,11 +55,11 @@ class EOSCalc(PropCalc):
             structure: pymatgen Structure object.
 
         Returns: {
-            EOS: {
+            eos: {
                 volumes: list[float] in Angstrom^3,
                 energies: list[float] in eV,
             },
-            bulk_modulus: Birch-Murnaghan bulk modulus in GPa.
+            bulk_modulus_bm: Birch-Murnaghan bulk modulus in GPa.
         }
         """
         if self.relax_structure:
@@ -82,6 +80,6 @@ class EOSCalc(PropCalc):
         bm.fit()
 
         return {
-            "EOS": {"volumes": volumes, "energies": energies},
-            "bulk_modulus": bm.b0_GPa,
+            "eos": {"volumes": volumes, "energies": energies},
+            "bulk_modulus_bm": bm.b0_GPa,
         }

--- a/matcalc/relaxation.py
+++ b/matcalc/relaxation.py
@@ -82,7 +82,7 @@ class RelaxCalc(PropCalc):
         """
         Args:
             calculator: ASE Calculator to use.
-            optimizer (str or ase Optimizer): The optimization algorithm. Defaults to "FIRE".
+            optimizer (str | ase Optimizer): The optimization algorithm. Defaults to "FIRE".
             steps (int): Max number of steps for relaxation. Defaults to 500.
             traj_file (str | None): File to save the trajectory to. Defaults to None.
             interval (int): The step interval for saving the trajectories. Defaults to 1.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,32 +1,10 @@
 [build-system]
-requires = [
-  # pin NumPy version used in the build
-  "oldest-supported-numpy",
-  "setuptools>=58.0.3",
-]
+requires = ["oldest-supported-numpy", "setuptools>=58.0.3"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 120
-target-version = ['py39']
-include = '\.pyi?$'
-exclude = '''
-(
-  /(
-      \.eggs         # exclude a few common directories in the
-    | \.git          # root of the project
-    | \.hg
-    | \.mypy_cache
-    | \.tox
-    | \.venv
-    | _build
-    | buck-out
-    | build
-    | dist
-    | test_files
-  )/
-)
-'''
+target-version = ["py39"]
 
 [tool.ruff]
 target-version = "py39"

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+"""Setup script for matcalc."""
+
 from __future__ import annotations
 
 from setuptools import find_packages, setup

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 """
-Define commonly used text fixtures. These are meant to be reused in unittests.
+This file defines commonly used test fixtures. These are meant to be reused in unit tests.
 - Fixtures that are formulae (e.g., LiFePO4) returns the appropriate pymatgen Structure or Molecule based on the most
   commonly known structure.
 - Fixtures that are prefixed with `graph_` returns a (structure, graph, state) tuple.
@@ -30,12 +30,6 @@ def Li2O():
 
 
 @pytest.fixture(scope="session")
-def M3GNetUPCalc():
+def M3GNetCalc():
     potential = matgl.load_model("M3GNet-MP-2021.2.8-PES")
     return M3GNetCalculator(potential=potential, stress_weight=0.01)
-
-
-# @pytest.fixture(scope="session")
-# def M3GNetUPCalc_tf():
-#     potential = Potential_tf(M3GNet_tf.load())
-#     return M3GNetCalculator_tf(potential=potential, stress_weight=0.01)

--- a/tests/test_elasticity.py
+++ b/tests/test_elasticity.py
@@ -6,9 +6,9 @@ import pytest
 from matcalc.elasticity import ElasticityCalc
 
 
-def test_ElasticCalc(LiFePO4, M3GNetUPCalc):
+def test_ElasticCalc(LiFePO4, M3GNetCalc):
     """Tests for ElasticCalc class"""
-    calculator = M3GNetUPCalc
+    calculator = M3GNetCalc
     ecalc = ElasticityCalc(calculator, norm_strains=0.02, shear_strains=0.04, fmax=0.1)
 
     # Test LiFePO4 with relaxation

--- a/tests/test_elasticity.py
+++ b/tests/test_elasticity.py
@@ -6,7 +6,7 @@ import pytest
 from matcalc.elasticity import ElasticityCalc
 
 
-def test_ElasticCalc(LiFePO4, M3GNetCalc):
+def test_elastic_calc(LiFePO4, M3GNetCalc):
     """Tests for ElasticCalc class"""
     calculator = M3GNetCalc
     ecalc = ElasticityCalc(calculator, norm_strains=0.02, shear_strains=0.04, fmax=0.1)

--- a/tests/test_eos.py
+++ b/tests/test_eos.py
@@ -13,8 +13,8 @@ def test_PhononCalc(Li2O, LiFePO4, M3GNetUPCalc):
     pcalc = EOSCalc(calculator, fmax=0.1)
     results = pcalc.calc(Li2O)
 
-    assert results["bulk_modulus"] == pytest.approx(69.86879801931632, rel=0.1)
+    assert results["bulk_modulus_bm"] == pytest.approx(69.86879801931632, rel=0.1)
 
     results = list(pcalc.calc_many([Li2O, LiFePO4]))
     assert len(results) == 2
-    assert results[1]["bulk_modulus"] == pytest.approx(60.083102790525366, rel=0.1)
+    assert results[1]["bulk_modulus_bm"] == pytest.approx(60.083102790525366, rel=0.1)

--- a/tests/test_eos.py
+++ b/tests/test_eos.py
@@ -6,9 +6,9 @@ import pytest
 from matcalc.eos import EOSCalc
 
 
-def test_PhononCalc(Li2O, LiFePO4, M3GNetUPCalc):
+def test_PhononCalc(Li2O, LiFePO4, M3GNetCalc):
     """Tests for PhononCalc class"""
-    calculator = M3GNetUPCalc
+    calculator = M3GNetCalc
     # Note that the fmax is probably too high. This is for testing purposes only.
     pcalc = EOSCalc(calculator, fmax=0.1)
     results = pcalc.calc(Li2O)

--- a/tests/test_eos.py
+++ b/tests/test_eos.py
@@ -6,7 +6,7 @@ import pytest
 from matcalc.eos import EOSCalc
 
 
-def test_PhononCalc(Li2O, LiFePO4, M3GNetCalc):
+def test_phonon_calc(Li2O, LiFePO4, M3GNetCalc):
     """Tests for PhononCalc class"""
     calculator = M3GNetCalc
     # Note that the fmax is probably too high. This is for testing purposes only.

--- a/tests/test_phonon.py
+++ b/tests/test_phonon.py
@@ -6,9 +6,9 @@ import pytest
 from matcalc.phonon import PhononCalc
 
 
-def test_PhononCalc(Li2O, LiFePO4, M3GNetUPCalc):
+def test_PhononCalc(Li2O, LiFePO4, M3GNetCalc):
     """Tests for PhononCalc class"""
-    calculator = M3GNetUPCalc
+    calculator = M3GNetCalc
     # Note that the fmax is probably too high. This is for testing purposes only.
     pcalc = PhononCalc(calculator, supercell_matrix=((2, 0, 0), (0, 2, 0), (0, 0, 2)), fmax=0.1, t_step=50, t_max=1000)
     results = pcalc.calc(Li2O)

--- a/tests/test_phonon.py
+++ b/tests/test_phonon.py
@@ -6,7 +6,7 @@ import pytest
 from matcalc.phonon import PhononCalc
 
 
-def test_PhononCalc(Li2O, LiFePO4, M3GNetCalc):
+def test_phonon_calc(Li2O, LiFePO4, M3GNetCalc):
     """Tests for PhononCalc class"""
     calculator = M3GNetCalc
     # Note that the fmax is probably too high. This is for testing purposes only.

--- a/tests/test_relaxation.py
+++ b/tests/test_relaxation.py
@@ -9,7 +9,7 @@ import pytest
 from matcalc.relaxation import RelaxCalc
 
 
-def test_RelaxCalc(LiFePO4, M3GNetCalc, tmp_path):
+def test_relax_calc(LiFePO4, M3GNetCalc, tmp_path):
     pcalc = RelaxCalc(M3GNetCalc, traj_file=f"{tmp_path}/lfp_relax.txt", optimizer="FIRE")
     results = pcalc.calc(LiFePO4)
     assert results["a"] == pytest.approx(4.75571137)

--- a/tests/test_relaxation.py
+++ b/tests/test_relaxation.py
@@ -9,8 +9,8 @@ import pytest
 from matcalc.relaxation import RelaxCalc
 
 
-def test_RelaxCalc(LiFePO4, M3GNetUPCalc, tmp_path):
-    pcalc = RelaxCalc(M3GNetUPCalc, traj_file=f"{tmp_path}/lfp_relax.txt", optimizer="FIRE")
+def test_RelaxCalc(LiFePO4, M3GNetCalc, tmp_path):
+    pcalc = RelaxCalc(M3GNetCalc, traj_file=f"{tmp_path}/lfp_relax.txt", optimizer="FIRE")
     results = pcalc.calc(LiFePO4)
     assert results["a"] == pytest.approx(4.75571137)
     assert results["b"] == pytest.approx(6.13161423)
@@ -25,4 +25,4 @@ def test_RelaxCalc(LiFePO4, M3GNetUPCalc, tmp_path):
     assert results[-1]["a"] == pytest.approx(4.7557113)
 
     with pytest.raises(ValueError, match="Unknown optimizer='invalid', must be one of "):
-        RelaxCalc(M3GNetUPCalc, optimizer="invalid")
+        RelaxCalc(M3GNetCalc, optimizer="invalid")


### PR DESCRIPTION
e690b16 delete black include/exclude in pyproject.toml
fe18bac link to PropCalc classes on GitHub from readme
6b46824 rename EOSCalc return dict keys: EOS->eos and bulk_modulus->bulk_modulus_bm
5a6bb44 fix test_PhononCalc following rename
c3e57ff rename pytest fixture M3GNetUPCalc -> M3GNetCalc
9126003 snake_case test names