### PR TITLE
Improve `EOSCalc` test coverage

### DIFF
--- a/matcalc/phonon.py
+++ b/matcalc/phonon.py
@@ -61,10 +61,10 @@ class PhononCalc(PropCalc):
             structure: Pymatgen structure.
 
         Returns: {
-            temperature: list of temperatures in Kelvin,
+            temperatures: list of temperatures in Kelvin,
             free_energy: list of Helmholtz free energies at corresponding temperatures in eV,
             entropy: list of entropies at corresponding temperatures in eV/K,
-            heat_capacities: list of heat capacities at constant volume at corresponding temperatures in eV/K^2,
+            heat_capacity: list of heat capacities at constant volume at corresponding temperatures in eV/K^2,
         }
         """
         if self.relax_structure:

--- a/tests/test_elasticity.py
+++ b/tests/test_elasticity.py
@@ -14,7 +14,7 @@ def test_elastic_calc(LiFePO4, M3GNetCalc):
     # Test LiFePO4 with relaxation
     results = ecalc.calc(LiFePO4)
     assert results["elastic_tensor"].shape == (3, 3, 3, 3)
-    assert results["elastic_tensor"][0][1][1][0] == pytest.approx(0.646330702693376, rel=0.1)
-    assert results["bulk_modulus_vrh"] == pytest.approx(1.109278785217532, rel=0.1)
-    assert results["shear_modulus_vrh"] == pytest.approx(0.5946891263210372, rel=0.1)
-    assert results["youngs_modulus"] == pytest.approx(1513587180.4865916, rel=0.1)
+    assert results["elastic_tensor"][0][1][1][0] == pytest.approx(0.646330702)
+    assert results["bulk_modulus_vrh"] == pytest.approx(1.109278785, rel=1e-2)
+    assert results["shear_modulus_vrh"] == pytest.approx(0.5946891263, rel=1e-2)
+    assert results["youngs_modulus"] == pytest.approx(1513587180.4, rel=1e-2)

--- a/tests/test_eos.py
+++ b/tests/test_eos.py
@@ -13,8 +13,8 @@ def test_phonon_calc(Li2O, LiFePO4, M3GNetCalc):
     pcalc = EOSCalc(calculator, fmax=0.1)
     results = pcalc.calc(Li2O)
 
-    assert results["bulk_modulus_bm"] == pytest.approx(69.86879801931632, rel=0.1)
+    assert results["bulk_modulus_bm"] == pytest.approx(69.868, rel=1e-2)
 
     results = list(pcalc.calc_many([Li2O, LiFePO4]))
     assert len(results) == 2
-    assert results[1]["bulk_modulus_bm"] == pytest.approx(60.083102790525366, rel=0.1)
+    assert results[1]["bulk_modulus_bm"] == pytest.approx(60.083, rel=1e-2)

--- a/tests/test_eos.py
+++ b/tests/test_eos.py
@@ -6,8 +6,8 @@ import pytest
 from matcalc.eos import EOSCalc
 
 
-def test_phonon_calc(Li2O, LiFePO4, M3GNetCalc):
-    """Tests for PhononCalc class"""
+def test_eos_calc(Li2O, LiFePO4, M3GNetCalc):
+    """Tests for EOSCalc class"""
     calculator = M3GNetCalc
     # Note that the fmax is probably too high. This is for testing purposes only.
     pcalc = EOSCalc(calculator, fmax=0.1)

--- a/tests/test_eos.py
+++ b/tests/test_eos.py
@@ -13,7 +13,17 @@ def test_eos_calc(Li2O, LiFePO4, M3GNetCalc):
     pcalc = EOSCalc(calculator, fmax=0.1)
     results = pcalc.calc(Li2O)
 
+    assert {*results} == {"eos", "bulk_modulus_bm"}
     assert results["bulk_modulus_bm"] == pytest.approx(69.868, rel=1e-2)
+    assert {*results["eos"]} == {"volumes", "energies"}
+    assert results["eos"]["volumes"] == pytest.approx(
+        [18.70, 19.97, 21.30, 22.69, 24.14, 25.65, 27.22, 28.85, 30.55, 32.31, 34.14],
+        rel=1e-3,
+    )
+    assert results["eos"]["energies"] == pytest.approx(
+        [-13.51, -13.78, -13.98, -14.11, -14.17, -14.19, -14.17, -14.12, -14.04, -13.94, -13.81],
+        rel=1e-3,
+    )
 
     results = list(pcalc.calc_many([Li2O, LiFePO4]))
     assert len(results) == 2

--- a/tests/test_phonon.py
+++ b/tests/test_phonon.py
@@ -15,10 +15,10 @@ def test_phonon_calc(Li2O, LiFePO4, M3GNetCalc):
 
     # Test values at 100 K
     ind = results["temperatures"].tolist().index(300)
-    assert results["heat_capacity"][ind] == pytest.approx(59.91894069664282, rel=0.1)
-    assert results["entropy"][ind] == pytest.approx(51.9081928335805, rel=0.1)
-    assert results["free_energy"][ind] == pytest.approx(11.892105644441045, rel=0.1)
+    assert results["heat_capacity"][ind] == pytest.approx(59.91894069664282, rel=1e-2)
+    assert results["entropy"][ind] == pytest.approx(51.9081928335805, rel=1e-2)
+    assert results["free_energy"][ind] == pytest.approx(11.892105644441045, rel=1e-2)
 
     results = list(pcalc.calc_many([Li2O, LiFePO4]))
     assert len(results) == 2
-    assert results[-1]["heat_capacity"][ind] == pytest.approx(550.6419940551511, rel=0.1)
+    assert results[-1]["heat_capacity"][ind] == pytest.approx(550.6419940551511, rel=1e-2)

--- a/tests/test_relaxation.py
+++ b/tests/test_relaxation.py
@@ -1,10 +1,6 @@
 from __future__ import annotations
 
-import os
-
-import matgl
 import pytest
-
 
 from matcalc.relaxation import RelaxCalc
 


### PR DESCRIPTION
2ed0f3e tighten pytest.appox rel tol
4f2f330 fix copy-paste name error test_phonon_calc->test_eos_calc
a6f128f test_eos_calc cover results["eos"]["volumes"] and results["eos"]["energies"]