### PR TITLE
Fixed the unit error in documentation of phonon.py

### DIFF
--- a/matcalc/phonon.py
+++ b/matcalc/phonon.py
@@ -56,7 +56,10 @@ class PhononCalc(PropCalc):
 
     def calc(self, structure: Structure) -> dict:
         """
-        Calculates thermal properties of Pymatgen structure with phonopy.
+        Calculates thermal properties of Pymatgen structure with phonopy. 
+        The units are documented in phonopy, See phonopy.Phonopy.run_thermal_properties() (https://github.com/phonopy/phonopy/blob/develop/phonopy/api_phonopy.py#L2591)
+        → phonopy.phonon.thermal_properties.ThermalProperties.run() (https://github.com/phonopy/phonopy/blob/develop/phonopy/phonon/thermal_properties.py#L498)
+        → phonopy.phonon.thermal_properties.ThermalPropertiesBase.run_free_energy(), run_entropy(), run_heat_capacity() (https://github.com/phonopy/phonopy/blob/develop/phonopy/phonon/thermal_properties.py#L217, #L233, #L225)
 
         Args:
             structure: Pymatgen structure.

--- a/matcalc/phonon.py
+++ b/matcalc/phonon.py
@@ -67,9 +67,9 @@ class PhononCalc(PropCalc):
             thermal_properties:
                 {
                     temperatures: list of temperatures in Kelvin,
-                    free_energy: list of Helmholtz free energies at corresponding temperatures in eV,
-                    entropy: list of entropies at corresponding temperatures in eV/K,
-                    heat_capacity: list of heat capacities at constant volume at corresponding temperatures in eV/K^2,
+                    free_energy: list of Helmholtz free energies at corresponding temperatures in KJ/mol,
+                    entropy: list of entropies at corresponding temperatures in J/K/mol,
+                    heat_capacity: list of heat capacities at constant volume at corresponding temperatures in J/K/mol,
                 }
         }
         """

--- a/matcalc/phonon.py
+++ b/matcalc/phonon.py
@@ -56,10 +56,7 @@ class PhononCalc(PropCalc):
 
     def calc(self, structure: Structure) -> dict:
         """
-        Calculates thermal properties of Pymatgen structure with phonopy. 
-        The units are documented in phonopy, See phonopy.Phonopy.run_thermal_properties() (https://github.com/phonopy/phonopy/blob/develop/phonopy/api_phonopy.py#L2591)
-        → phonopy.phonon.thermal_properties.ThermalProperties.run() (https://github.com/phonopy/phonopy/blob/develop/phonopy/phonon/thermal_properties.py#L498)
-        → phonopy.phonon.thermal_properties.ThermalPropertiesBase.run_free_energy(), run_entropy(), run_heat_capacity() (https://github.com/phonopy/phonopy/blob/develop/phonopy/phonon/thermal_properties.py#L217, #L233, #L225)
+        Calculates thermal properties of Pymatgen structure with phonopy.
 
         Args:
             structure: Pymatgen structure.

--- a/matcalc/phonon.py
+++ b/matcalc/phonon.py
@@ -67,9 +67,17 @@ class PhononCalc(PropCalc):
             thermal_properties:
                 {
                     temperatures: list of temperatures in Kelvin,
-                    free_energy: list of Helmholtz free energies at corresponding temperatures in KJ/mol,
+                    free_energy: list of Helmholtz free energies at corresponding temperatures in kJ/mol,
                     entropy: list of entropies at corresponding temperatures in J/K/mol,
                     heat_capacity: list of heat capacities at constant volume at corresponding temperatures in J/K/mol,
+                    
+                    The units are originally documented in phonopy.
+                    See phonopy.Phonopy.run_thermal_properties()
+                    (https://github.com/phonopy/phonopy/blob/develop/phonopy/api_phonopy.py#L2591)
+                    -> phonopy.phonon.thermal_properties.ThermalProperties.run()
+                    (https://github.com/phonopy/phonopy/blob/develop/phonopy/phonon/thermal_properties.py#L498)
+                    -> phonopy.phonon.thermal_properties.ThermalPropertiesBase.run_free_energy(), run_entropy(), run_heat_capacity()
+                    (https://github.com/phonopy/phonopy/blob/develop/phonopy/phonon/thermal_properties.py#L217, #L233, #L225)
                 }
         }
         """

--- a/matcalc/phonon.py
+++ b/matcalc/phonon.py
@@ -70,14 +70,17 @@ class PhononCalc(PropCalc):
                     free_energy: list of Helmholtz free energies at corresponding temperatures in kJ/mol,
                     entropy: list of entropies at corresponding temperatures in J/K/mol,
                     heat_capacity: list of heat capacities at constant volume at corresponding temperatures in J/K/mol,
-                    
                     The units are originally documented in phonopy.
                     See phonopy.Phonopy.run_thermal_properties()
                     (https://github.com/phonopy/phonopy/blob/develop/phonopy/api_phonopy.py#L2591)
                     -> phonopy.phonon.thermal_properties.ThermalProperties.run()
                     (https://github.com/phonopy/phonopy/blob/develop/phonopy/phonon/thermal_properties.py#L498)
-                    -> phonopy.phonon.thermal_properties.ThermalPropertiesBase.run_free_energy(), run_entropy(), run_heat_capacity()
-                    (https://github.com/phonopy/phonopy/blob/develop/phonopy/phonon/thermal_properties.py#L217, #L233, #L225)
+                    -> phonopy.phonon.thermal_properties.ThermalPropertiesBase.run_free_energy()
+                    (https://github.com/phonopy/phonopy/blob/develop/phonopy/phonon/thermal_properties.py#L217)
+                    phonopy.phonon.thermal_properties.ThermalPropertiesBase.run_entropy()
+                    (https://github.com/phonopy/phonopy/blob/develop/phonopy/phonon/thermal_properties.py#L233)
+                    phonopy.phonon.thermal_properties.ThermalPropertiesBase.run_heat_capacity()
+                    (https://github.com/phonopy/phonopy/blob/develop/phonopy/phonon/thermal_properties.py#L225)
                 }
         }
         """


### PR DESCRIPTION
The unit is incorrect.

## Summary

Major changes:

- feature 1: ...
- fix 1: ...

## Todos

If this is work in progress, what else needs to be done?

- feature 2: ...
- fix 2:

## Checklist

- [ ] Google format doc strings added. Check with `ruff`.
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
