### PR TITLE
Enforce using dgl==1.1.3 in requirement-ci.txt

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ ci:
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.2
+    rev: v0.3.3
     hooks:
       - id: ruff
         args: [--fix]
@@ -21,7 +21,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
+    rev: v1.9.0
     hooks:
       - id: mypy
 
@@ -48,6 +48,6 @@ repos:
         args: [--drop-empty-cells, --keep-output]
 
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.351
+    rev: v1.1.354
     hooks:
       - id: pyright

--- a/matcalc/base.py
+++ b/matcalc/base.py
@@ -1,4 +1,5 @@
 """Define basic API."""
+
 from __future__ import annotations
 
 import abc

--- a/matcalc/neb.py
+++ b/matcalc/neb.py
@@ -1,4 +1,5 @@
 """NEB calculations."""
+
 from __future__ import annotations
 
 import os

--- a/matcalc/relaxation.py
+++ b/matcalc/relaxation.py
@@ -1,4 +1,5 @@
 """Relaxation properties."""
+
 from __future__ import annotations
 
 import contextlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,8 @@ packages = ["matcalc"]
 [tool.ruff]
 target-version = "py39"
 line-length = 120
+
+[tool.ruff.lint]
 select = ["ALL"]
 ignore = [
     "ANN101",
@@ -63,6 +65,7 @@ ignore = [
     "EM102",
     "FBT001",
     "FBT002",
+    "ISC001",
     "PLR",     # pylint refactor
     "PLW0603", # Using the global statement to update variables is discouraged
     "PTH",     # prefer Path to os.path
@@ -73,7 +76,7 @@ exclude = ["docs/conf.py"]
 pydocstyle.convention = "google"
 isort.required-imports = ["from __future__ import annotations"]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
 "tasks.py" = ["ANN", "D", "T203"]
 "tests/*" = ["D", "INP001", "N802", "N803", "S101"]

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -5,5 +5,6 @@ coveralls
 mypy
 ruff
 black
-matgl==1.0.0
+dgl==1.1.3
+matgl==0.9.1
 chgnet==0.2.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -7,4 +7,4 @@ ruff
 black
 dgl==1.1.3
 matgl==0.9.1
-chgnet==0.2.0
+chgnet

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -5,5 +5,5 @@ coveralls
 mypy
 ruff
 black
-matgl==0.9.1
+matgl==1.0.0
 chgnet==0.2.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ Given that the fixtures are unlikely to be modified by the underlying code, the 
 "session". In the event that future tests are written that modifies the fixtures, these can be set to the default scope
 of "function".
 """
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/tests/test_elasticity.py
+++ b/tests/test_elasticity.py
@@ -1,4 +1,5 @@
 """Tests for ElasticCalc class"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/tests/test_eos.py
+++ b/tests/test_eos.py
@@ -1,4 +1,5 @@
 """Tests for PhononCalc class"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/tests/test_phonon.py
+++ b/tests/test_phonon.py
@@ -1,4 +1,5 @@
 """Tests for PhononCalc class"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING


### PR DESCRIPTION
Enforce using `dgl==1.1.3` in `requirement-ci.txt`

I have gone through the problem of pydantic, which comes from the graphbolt developed in dgl.2.0.0 or later version. graphbolt is a dataloading framework for GNN that provides well-defined APIs for each stage of the data pipeline and multiple standard implementations. I am not sure if we could just simply remove it from dgl package. At the moment, I think we can enforce using dgl.1.1.3 instead so that all united tests work. However, I don't understand why ruff crashes.