### PR TITLE
Calculated and saved more necessary phonon calculation results

### DIFF
--- a/matcalc/phonon.py
+++ b/matcalc/phonon.py
@@ -60,7 +60,7 @@ class PhononCalc(PropCalc):
                 Defaults to False.
             write_phonon: Whether to save phonon object. Set to True to save necesssary phonon
                 calculation results. Band structure, density of states, thermal properties,
-                etc. can be rebuilt from this file using the phonopy API via phonopy.load("phonon.yaml")
+                etc. can be rebuilt from this file using the phonopy API via phonopy.load("phonon.yaml").
         """
         self.calculator = calculator
         self.atom_disp = atom_disp

--- a/matcalc/phonon.py
+++ b/matcalc/phonon.py
@@ -51,14 +51,14 @@ class PhononCalc(PropCalc):
             t_min: Min temperature (in Kelvin).
             relax_structure: Whether to first relax the structure. Set to False if structures
                 provided are pre-relaxed with the same calculator.
-            write_force_constants: Whether to save force constants. Set to False for storage 
-                conservation. This file can be very large, be careful when doing high-throughput 
+            write_force_constants: Whether to save force constants. Set to False for storage
+                conservation. This file can be very large, be careful when doing high-throughput
                 calculations.
             write_band_structure: Whether to calculate and save band structure (in yaml format).
                 Defaults to False.
             write_total_dos: Whether to calculate and save density of states (in dat format).
                 Defaults to False.
-            write_phonon: Whether to save phonon object. Set to True to save necesssary phonon 
+            write_phonon: Whether to save phonon object. Set to True to save necesssary phonon
                 calculation results. Band structure, density of states, thermal properties,
                 etc. can be rebuilt from this file using the phonopy API via phonopy.load("phonon.yaml")
         """
@@ -119,19 +119,14 @@ class PhononCalc(PropCalc):
         phonon.produce_force_constants()
         phonon.run_mesh()
         phonon.run_thermal_properties(t_step=self.t_step, t_max=self.t_max, t_min=self.t_min)
-
         if self.write_force_constants:
             write_FORCE_CONSTANTS(phonon.force_constants, filename="FORCE_CONSTANTS")
-
         if self.write_band_structure:
             phonon.auto_band_structure(write_yaml=True, filename="phonon_band_structure.yaml")
-
         if self.write_total_dos:
             phonon.auto_total_dos(write_dat=True, filename="phonon_total_dos.dat")
-
         if self.write_phonon:
             phonon.save("phonon.yaml")
-            
         return {"phonon": phonon, "thermal_properties": phonon.get_thermal_properties_dict()}
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ ase==3.22.1
 joblib==1.3.1
 phonopy==2.20.0
 scikit-learn>=1.3.0
+seekpath==2.1.0

--- a/tests/test_phonon.py
+++ b/tests/test_phonon.py
@@ -1,6 +1,8 @@
 """Tests for PhononCalc class"""
+
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 
 import pytest
@@ -8,15 +10,25 @@ import pytest
 from matcalc.phonon import PhononCalc
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from matgl.ext.ase import M3GNetCalculator
     from pymatgen.core import Structure
 
 
-def test_phonon_calc(Li2O: Structure, M3GNetCalc: M3GNetCalculator) -> None:
+def test_phonon_calc(Li2O: Structure, M3GNetCalc: M3GNetCalculator, tmp_path: Path) -> None:
     """Tests for PhononCalc class"""
     # Note that the fmax is probably too high. This is for testing purposes only.
+
+    # change dir to tmp_path
+    phonon_yaml = tmp_path / "phonon.yaml"
     phonon_calc = PhononCalc(
-        M3GNetCalc, supercell_matrix=((2, 0, 0), (0, 2, 0), (0, 0, 2)), fmax=0.1, t_step=50, t_max=1000
+        M3GNetCalc,
+        supercell_matrix=((2, 0, 0), (0, 2, 0), (0, 0, 2)),
+        fmax=0.1,
+        t_step=50,
+        t_max=1000,
+        write_phonon=phonon_yaml,
     )
     result = phonon_calc.calc(Li2O)
 
@@ -28,3 +40,5 @@ def test_phonon_calc(Li2O: Structure, M3GNetCalc: M3GNetCalculator) -> None:
 
     results = list(phonon_calc.calc_many([Li2O, Li2O]))
     assert len(results) == 2
+
+    assert os.path.isfile(phonon_yaml)

--- a/tests/test_phonon.py
+++ b/tests/test_phonon.py
@@ -16,15 +16,15 @@ if TYPE_CHECKING:
     from pymatgen.core import Structure
 
 
-def test_phonon_calc(Li2O: Structure, M3GNetCalc: M3GNetCalculator, force_constants_tmp_path: Path, band_structure_tmp_path: Path, total_dos_tmp_path: Path, phonon_tmp_path: Path) -> None:
+def test_phonon_calc(Li2O: Structure, M3GNetCalc: M3GNetCalculator, tmp_path: Path) -> None:
     """Tests for PhononCalc class"""
     # Note that the fmax is probably too high. This is for testing purposes only.
 
     # change dir to tmp_path
-    force_constants = force_constants_tmp_path / "force_constants"
-    band_structure_yaml = band_structure_tmp_path / "band_structure.yaml"
-    total_dos_dat = total_dos_tmp_path / "total_dos.dat"
-    phonon_yaml = phonon_tmp_path / "phonon.yaml"
+    force_constants = tmp_path / "force_constants"
+    band_structure_yaml = tmp_path / "band_structure.yaml"
+    total_dos_dat = tmp_path / "total_dos.dat"
+    phonon_yaml = tmp_path / "phonon.yaml"
     phonon_calc = PhononCalc(
         M3GNetCalc,
         supercell_matrix=((2, 0, 0), (0, 2, 0), (0, 0, 2)),

--- a/tests/test_phonon.py
+++ b/tests/test_phonon.py
@@ -16,18 +16,24 @@ if TYPE_CHECKING:
     from pymatgen.core import Structure
 
 
-def test_phonon_calc(Li2O: Structure, M3GNetCalc: M3GNetCalculator, tmp_path: Path) -> None:
+def test_phonon_calc(Li2O: Structure, M3GNetCalc: M3GNetCalculator, force_constants_tmp_path: Path, band_structure_tmp_path: Path, total_dos_tmp_path: Path, phonon_tmp_path: Path) -> None:
     """Tests for PhononCalc class"""
     # Note that the fmax is probably too high. This is for testing purposes only.
 
     # change dir to tmp_path
-    phonon_yaml = tmp_path / "phonon.yaml"
+    force_constants = force_constants_tmp_path / "force_constants"
+    band_structure_yaml = band_structure_tmp_path / "band_structure.yaml"
+    total_dos_dat = total_dos_tmp_path / "total_dos.dat"
+    phonon_yaml = phonon_tmp_path / "phonon.yaml"
     phonon_calc = PhononCalc(
         M3GNetCalc,
         supercell_matrix=((2, 0, 0), (0, 2, 0), (0, 0, 2)),
         fmax=0.1,
         t_step=50,
         t_max=1000,
+        write_force_constants=force_constants,
+        write_band_structure=band_structure_yaml,
+        write_total_dos=total_dos_dat,
         write_phonon=phonon_yaml,
     )
     result = phonon_calc.calc(Li2O)
@@ -41,4 +47,7 @@ def test_phonon_calc(Li2O: Structure, M3GNetCalc: M3GNetCalculator, tmp_path: Pa
     results = list(phonon_calc.calc_many([Li2O, Li2O]))
     assert len(results) == 2
 
+    assert os.path.isfile(force_constants)
+    assert os.path.isfile(band_structure_yaml)
+    assert os.path.isfile(total_dos_dat)
     assert os.path.isfile(phonon_yaml)


### PR DESCRIPTION
Our codes used to only allow the calculation and return of thermal properties, ignoring band structure, force constants, etc., which limited further investigation, like dynamic stability, anharmonicity, etc.

In this update, we added several features. Phonon object was saved by default because it contained a lot of information, and the band structure, density of states, etc. can be reconstructed from this file. We also allowed users to determine whether to calculate and save band structure, density of states and force constants. (Default to False to ensure consistency with previous code and save storage space)

## Summary

Major changes:

- feature 1: ...
- fix 1: ...

## Todos

If this is work in progress, what else needs to be done?

- feature 2: ...
- fix 2:

## Checklist

- [ ] Google format doc strings added. Check with `ruff`.
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
