### PR TITLE
Add static calculation feature to matcalc/relaxation.py

### DIFF
--- a/matcalc/relaxation.py
+++ b/matcalc/relaxation.py
@@ -146,7 +146,7 @@ class RelaxCalc(PropCalc):
             energy = obs.energies[-1]
         else:
             energy = atoms.get_potential_energy()
-            
+
         final_structure = AseAtomsAdaptor.get_structure(atoms)
         lattice = final_structure.lattice
 

--- a/matcalc/relaxation.py
+++ b/matcalc/relaxation.py
@@ -79,6 +79,7 @@ class RelaxCalc(PropCalc):
         traj_file: str | None = None,
         interval: int = 1,
         fmax: float = 0.1,
+        relax_atoms: bool = True,
         relax_cell: bool = True,
         cell_filter: Filter = FrechetCellFilter,
     ) -> None:
@@ -90,6 +91,7 @@ class RelaxCalc(PropCalc):
             interval (int): The step interval for saving the trajectories. Defaults to 1.
             fmax (float): Total force tolerance for relaxation convergence.
                 fmax is a sum of force and stress forces. Defaults to 0.1 (eV/A).
+            relax_atoms (bool): Whether to relax the atoms (or just static calculation).
             relax_cell (bool): Whether to relax the cell (or just atoms).
             cell_filter (Filter): The ASE Filter used to relax the cell. Default is FrechetCellFilter.
 
@@ -103,6 +105,7 @@ class RelaxCalc(PropCalc):
         self.interval = interval
         self.max_steps = max_steps
         self.traj_file = traj_file
+        self.relax_atoms = relax_atoms
         self.relax_cell = relax_cell
         self.cell_filter = cell_filter
 
@@ -113,8 +116,8 @@ class RelaxCalc(PropCalc):
             structure: Pymatgen structure.
 
         Returns: {
-            final_structure: final_structure,
-            energy: trajectory observer final energy in eV,
+            final_structure: final structure,
+            energy: static energy or trajectory observer final energy in eV,
             volume: lattice.volume in A^3,
             a: lattice.a in A,
             b: lattice.b in A,
@@ -126,26 +129,30 @@ class RelaxCalc(PropCalc):
         """
         atoms = AseAtomsAdaptor.get_atoms(structure)
         atoms.calc = self.calculator
-        stream = io.StringIO()
-        with contextlib.redirect_stdout(stream):
-            obs = TrajectoryObserver(atoms)
+        if self.relax_atoms:
+            stream = io.StringIO()
+            with contextlib.redirect_stdout(stream):
+                obs = TrajectoryObserver(atoms)
+                if self.relax_cell:
+                    atoms = self.cell_filter(atoms)
+                optimizer = self.optimizer(atoms)
+                optimizer.attach(obs, interval=self.interval)
+                optimizer.run(fmax=self.fmax, steps=self.max_steps)
+                if self.traj_file is not None:
+                    obs()
+                    obs.save(self.traj_file)
             if self.relax_cell:
-                atoms = self.cell_filter(atoms)
-            optimizer = self.optimizer(atoms)
-            optimizer.attach(obs, interval=self.interval)
-            optimizer.run(fmax=self.fmax, steps=self.max_steps)
-            if self.traj_file is not None:
-                obs()
-                obs.save(self.traj_file)
-        if self.relax_cell:
-            atoms = atoms.atoms
-
+                atoms = atoms.atoms
+            energy = obs.energies[-1]
+        else:
+            energy = atoms.get_potential_energy()
+            
         final_structure = AseAtomsAdaptor.get_structure(atoms)
         lattice = final_structure.lattice
 
         return {
             "final_structure": final_structure,
-            "energy": obs.energies[-1],
+            "energy": energy,
             "a": lattice.a,
             "b": lattice.b,
             "c": lattice.c,

--- a/matcalc/relaxation.py
+++ b/matcalc/relaxation.py
@@ -160,13 +160,13 @@ class RelaxCalc(PropCalc):
                 "gamma": lattice.gamma,
                 "volume": lattice.volume,
             }
-        else:
-            energy = atoms.get_potential_energy()
-            forces = atoms.get_forces()
-            stresses = atoms.get_stress()
 
-            return {
-                "energy": energy,
-                "forces": forces,
-                "stress": stresses,
-            }
+        energy = atoms.get_potential_energy()
+        forces = atoms.get_forces()
+        stresses = atoms.get_stress()
+
+        return {
+            "energy": energy,
+            "forces": forces,
+            "stress": stresses,
+        }

--- a/tests/test_relaxation.py
+++ b/tests/test_relaxation.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
 @pytest.mark.parametrize(
     ("cell_filter", "expected_a", "expected_energy"),
-    [(ExpCellFilter, 3.288585, -14.176882), (FrechetCellFilter, 3.291071, -14.176743)],
+    [(ExpCellFilter, 3.288585, -14.176867), (FrechetCellFilter, 3.291072, -14.176713)],
 )
 def test_relax_calc_relax_cell(
     Li2O: Structure,
@@ -54,7 +54,7 @@ def test_relax_calc_relax_cell(
     assert final_struct.volume == pytest.approx(a * b * c / 2**0.5, abs=0.1)
 
 
-@pytest.mark.parametrize(("expected_a", "expected_energy"), [(3.291071, -14.1767423)])
+@pytest.mark.parametrize(("expected_a", "expected_energy"), [(3.291072, -14.176713)])
 def test_relax_calc_relax_atoms(
     Li2O: Structure, M3GNetCalc: M3GNetCalculator, tmp_path: Path, expected_a: float, expected_energy: float
 ) -> None:
@@ -82,28 +82,27 @@ def test_relax_calc_relax_atoms(
     ("expected_energy", "expected_forces", "expected_stresses"),
     [
         (
-            -14.176743,
+            -14.176713,
             np.array(
                 [
-                    [-4.252263e-03, -3.029412e-03, -7.360560e-03],
-                    [4.272716e-03, 3.017864e-03, 7.360807e-03],
-                    [-2.035008e-05, 1.152878e-05, -2.714805e-07],
+                    [6.577218e-06, 1.851469e-06, -7.080846e-06],
+                    [-4.507415e-03, -3.310852e-03, -7.090813e-03],
+                    [4.500971e-03, 3.309000e-03, 7.097944e-03],
                 ],
                 dtype=np.float32,
             ),
-            np.array([0.003945, 0.004185, 0.003000, -0.000584, -0.000826, -0.000337], dtype=np.float32),
+            np.array([0.003883, 0.004126, 0.003089, -0.000617, -0.000839, -0.000391], dtype=np.float32),
         ),
     ],
 )
 def test_static_calc(
     Li2O: Structure,
     M3GNetCalc: M3GNetCalculator,
-    tmp_path: Path,
     expected_energy: float,
     expected_forces: ArrayLike,
     expected_stresses: ArrayLike,
 ) -> None:
-    relax_calc = RelaxCalc(M3GNetCalc, traj_file=f"{tmp_path}/li2o_relax.txt", relax_atoms=False, relax_cell=False)
+    relax_calc = RelaxCalc(M3GNetCalc, relax_atoms=False, relax_cell=False)
     result = relax_calc.calc(Li2O)
 
     energy: float = result["energy"]
@@ -115,7 +114,7 @@ def test_static_calc(
     assert np.allclose(stresses, expected_stresses, rtol=1e-3)
 
 
-@pytest.mark.parametrize(("cell_filter", "expected_a"), [(ExpCellFilter, 3.288585), (FrechetCellFilter, 3.291071)])
+@pytest.mark.parametrize(("cell_filter", "expected_a"), [(ExpCellFilter, 3.288585), (FrechetCellFilter, 3.291072)])
 def test_relax_calc_many(Li2O: Structure, M3GNetCalc: M3GNetCalculator, cell_filter: Filter, expected_a: float) -> None:
     relax_calc = RelaxCalc(M3GNetCalc, optimizer="FIRE", cell_filter=cell_filter)
     results = list(relax_calc.calc_many([Li2O] * 2))

--- a/tests/test_relaxation.py
+++ b/tests/test_relaxation.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 
     from ase.filters import Filter
     from matgl.ext.ase import M3GNetCalculator
+    from numpy.typing import ArrayLike
     from pymatgen.core import Structure
 
 
@@ -41,7 +42,7 @@ def test_relax_calc_relax_cell(
 
 @pytest.mark.parametrize("expected_a", [3.288585])
 def test_relax_calc_relax_atoms(
-    Li2O: Structure, M3GNetCalc: M3GNetCalculator, tmp_path: Path, cell_filter: Filter, expected_a: float
+    Li2O: Structure, M3GNetCalc: M3GNetCalculator, tmp_path: Path, expected_a: float
 ) -> None:
     relax_calc = RelaxCalc(
         M3GNetCalc, traj_file=f"{tmp_path}/li2o_relax.txt", optimizer="FIRE", relax_atoms=True, relax_cell=False
@@ -63,16 +64,16 @@ def test_relax_calc_relax_atoms(
     assert isinstance(energy, float)
 
 def test_static_calc(
-    Li2O: Structure, M3GNetCalc: M3GNetCalculator, tmp_path: Path, cell_filter: Filter, expected_a: float
+    Li2O: Structure, M3GNetCalc: M3GNetCalculator, tmp_path: Path
 ) -> None:
     relax_calc = RelaxCalc(
         M3GNetCalc, traj_file=f"{tmp_path}/li2o_relax.txt", relax_atoms=False, relax_cell=False
     )
     result = relax_calc.calc(Li2O)
 
-    energy = result["energy"]
-    forces = result["forces"]
-    stresses = result["stress"]
+    energy: float = result["energy"]
+    forces: ArrayLike = result["forces"]
+    stresses: ArrayLike = result["stress"]
 
     assert isinstance(forces, float)
     assert list(forces.shape) == [3, 3]

--- a/tests/test_relaxation.py
+++ b/tests/test_relaxation.py
@@ -75,7 +75,7 @@ def test_static_calc(
     forces: ArrayLike = result["forces"]
     stresses: ArrayLike = result["stress"]
 
-    assert isinstance(forces, float)
+    assert isinstance(energy, float)
     assert list(forces.shape) == [3, 3]
     assert list(stresses.shape) == [6]
 

--- a/tests/test_relaxation.py
+++ b/tests/test_relaxation.py
@@ -16,14 +16,15 @@ if TYPE_CHECKING:
 
 
 @pytest.mark.parametrize(("cell_filter", "expected_a"), [(ExpCellFilter, 3.291071), (FrechetCellFilter, 3.288585)])
-def test_relax_calc_single(
+def test_relax_calc_relax_cell(
     Li2O: Structure, M3GNetCalc: M3GNetCalculator, tmp_path: Path, cell_filter: Filter, expected_a: float
 ) -> None:
     relax_calc = RelaxCalc(
-        M3GNetCalc, traj_file=f"{tmp_path}/li2o_relax.txt", optimizer="FIRE", cell_filter=cell_filter
+        M3GNetCalc, traj_file=f"{tmp_path}/li2o_relax.txt", optimizer="FIRE", cell_filter=cell_filter, relax_atoms=True, relax_cell=True
     )
     result = relax_calc.calc(Li2O)
     final_struct: Structure = result["final_structure"]
+    energy: float = result["energy"]
     missing_keys = {*final_struct.lattice.params_dict} - {*result}
     assert len(missing_keys) == 0, f"{missing_keys=}"
     a, b, c, alpha, beta, gamma = final_struct.lattice.parameters
@@ -35,7 +36,47 @@ def test_relax_calc_single(
     assert beta == pytest.approx(60, abs=0.5)
     assert gamma == pytest.approx(60, abs=0.5)
     assert final_struct.volume == pytest.approx(a * b * c / 2**0.5, abs=0.1)
+    assert isinstance(energy, float)
 
+
+@pytest.mark.parametrize("expected_a", [3.288585])
+def test_relax_calc_relax_atoms(
+    Li2O: Structure, M3GNetCalc: M3GNetCalculator, tmp_path: Path, cell_filter: Filter, expected_a: float
+) -> None:
+    relax_calc = RelaxCalc(
+        M3GNetCalc, traj_file=f"{tmp_path}/li2o_relax.txt", optimizer="FIRE", relax_atoms=True, relax_cell=False
+    )
+    result = relax_calc.calc(Li2O)
+    final_struct: Structure = result["final_structure"]
+    energy: float = result["energy"]
+    missing_keys = {*final_struct.lattice.params_dict} - {*result}
+    assert len(missing_keys) == 0, f"{missing_keys=}"
+    a, b, c, alpha, beta, gamma = final_struct.lattice.parameters
+
+    assert a == pytest.approx(expected_a, rel=1e-3)
+    assert b == pytest.approx(expected_a, rel=1e-3)
+    assert c == pytest.approx(expected_a, rel=1e-3)
+    assert alpha == pytest.approx(60, abs=0.5)
+    assert beta == pytest.approx(60, abs=0.5)
+    assert gamma == pytest.approx(60, abs=0.5)
+    assert final_struct.volume == pytest.approx(a * b * c / 2**0.5, abs=0.1)
+    assert isinstance(energy, float)
+
+def test_static_calc(
+    Li2O: Structure, M3GNetCalc: M3GNetCalculator, tmp_path: Path, cell_filter: Filter, expected_a: float
+) -> None:
+    relax_calc = RelaxCalc(
+        M3GNetCalc, traj_file=f"{tmp_path}/li2o_relax.txt", relax_atoms=False, relax_cell=False
+    )
+    result = relax_calc.calc(Li2O)
+
+    energy = result["energy"]
+    forces = result["forces"]
+    stresses = result["stress"]
+
+    assert isinstance(forces, float)
+    assert list(forces.shape) == [3, 3]
+    assert list(stresses.shape) == [6]
 
 @pytest.mark.parametrize(("cell_filter", "expected_a"), [(ExpCellFilter, 3.291071), (FrechetCellFilter, 3.288585)])
 def test_relax_calc_many(Li2O: Structure, M3GNetCalc: M3GNetCalculator, cell_filter: Filter, expected_a: float) -> None:

--- a/tests/test_relaxation.py
+++ b/tests/test_relaxation.py
@@ -79,7 +79,7 @@ def test_relax_calc_relax_atoms(
 
 
 @pytest.mark.parametrize(
-    ("expected_energy", "expected_forces", "expected_stress"),
+    ("expected_energy", "expected_forces", "expected_stresses"),
     [
         (
             -14.176743,


### PR DESCRIPTION
In the original relaxation.py, users are allowed to do cell relaxation or atoms only relaxation. Static calculation is an important feature itself and also part of some complex applications (eg. QHA). As MatCalc provides a universal interface for different uMLIPs, how about we add this feature to RelaxCalc? The default is still cell relaxation, and user can set "relax_atoms" and "relax_cell" to False to do static calculation.

## Summary

Major changes:

- feature 1: ...
- fix 1: ...

## Todos

If this is work in progress, what else needs to be done?

- feature 2: ...
- fix 2:

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
