### PR TITLE
Set the explicit version for dgl and pytorch in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,11 +35,11 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Physics",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-dependencies = ["ase>=3.23.0", "joblib", "phonopy", "pymatgen"]
+dependencies = ["ase>=3.23.0", "joblib", "phonopy", "pymatgen", "numpy<2.0.0"]
 version = "0.0.4"
 
 [project.optional-dependencies]
-models = ["chgnet>=0.3.8", "mace-torch>=0.3.6", "matgl>=1.0.0", "sevenn>=0.9.3", "dgl==2.2.1", "torch==2.4.0"]
+models = ["chgnet>=0.3.8", "mace-torch>=0.3.6", "matgl>=1.0.0", "sevenn>=0.9.3", "dgl==2.1.0", "torch==2.4.0"]
 
 [tool.setuptools]
 packages = ["matcalc"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = ["ase>=3.23.0", "joblib", "phonopy", "pymatgen", "numpy<2.0.0"]
 version = "0.0.4"
 
 [project.optional-dependencies]
-models = ["chgnet>=0.3.8", "mace-torch>=0.3.6", "matgl>=1.0.0", "sevenn>=0.9.3", "dgl==2.1.0", "torch==2.4.0"]
+models = ["chgnet>=0.3.8", "mace-torch>=0.3.6", "matgl>=1.0.0", "sevenn>=0.9.3", "dgl<=2.1.0", "torch<=2.2.1"]
 
 [tool.setuptools]
 packages = ["matcalc"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = ["ase>=3.23.0", "joblib", "phonopy", "pymatgen"]
 version = "0.0.4"
 
 [project.optional-dependencies]
-models = ["chgnet>=0.3.8", "mace-torch>=0.3.6", "matgl>=0.9.0", "sevenn>=0.9.3"]
+models = ["chgnet>=0.3.8", "mace-torch>=0.3.6", "matgl>=1.0.0", "sevenn>=0.9.3", "dgl==2.2.1", "torch==2.4.0"]
 
 [tool.setuptools]
 packages = ["matcalc"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ joblib==1.3.1
 phonopy==2.20.0
 scikit-learn>=1.3.0
 seekpath==2.1.0
+numpy==1.26.4


### PR DESCRIPTION
## Summary
Set the correct versions of DGL and PyTorch to avoid crashes.


## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
