### PR TITLE
Option to relax strained structures in ElasticityCalc

### DIFF
--- a/src/matcalc/elasticity.py
+++ b/src/matcalc/elasticity.py
@@ -44,8 +44,8 @@ class ElasticityCalc(PropCalc):
             fmax: maximum force in the relaxed structure (if relax_structure). Defaults to 0.1.
             relax_structure: whether to relax the provided structure with the given calculator.
                 Defaults to True.
-            relax_structure: whether to relax the atomic positions of the deformed/strained structures with the given
-                calculator. Defaults to True.
+            relax_deformed_structures: whether to relax the atomic positions of the deformed/strained structures
+                with the given calculator. Defaults to True.
             use_equilibrium: whether to use the equilibrium stress and strain. Ignored and set
                 to True if either norm_strains or shear_strains has length 1 or is a float.
                 Defaults to True.
@@ -100,9 +100,11 @@ class ElasticityCalc(PropCalc):
         stresses = []
         for deformed_structure in deformed_structure_set:
             if self.relax_deformed_structures:
-                deformed_structure = relax_calc.calc(deformed_structure)["final_structure"]
+                deformed_structure_relaxed = relax_calc.calc(deformed_structure)["final_structure"]
+                atoms = deformed_structure_relaxed.to_ase_atoms()
+            else:
+                atoms = deformed_structure.to_ase_atoms()
 
-            atoms = deformed_structure.to_ase_atoms()
             atoms.calc = self.calculator
             stresses.append(atoms.get_stress(voigt=False))
 

--- a/src/matcalc/elasticity.py
+++ b/src/matcalc/elasticity.py
@@ -30,6 +30,7 @@ class ElasticityCalc(PropCalc):
         shear_strains: Sequence[float] | float = (-0.06, -0.03, 0.03, 0.06),
         fmax: float = 0.1,
         relax_structure: bool = True,
+        relax_deformed_structures: bool = False,
         use_equilibrium: bool = True,
         relax_calc_kwargs: dict | None = None,
     ) -> None:
@@ -43,6 +44,8 @@ class ElasticityCalc(PropCalc):
             fmax: maximum force in the relaxed structure (if relax_structure). Defaults to 0.1.
             relax_structure: whether to relax the provided structure with the given calculator.
                 Defaults to True.
+            relax_structure: whether to relax the atomic positions of the deformed/strained structures with the given
+                calculator. Defaults to True.
             use_equilibrium: whether to use the equilibrium stress and strain. Ignored and set
                 to True if either norm_strains or shear_strains has length 1 or is a float.
                 Defaults to True.
@@ -59,6 +62,7 @@ class ElasticityCalc(PropCalc):
         if 0 in self.norm_strains or 0 in self.shear_strains:
             raise ValueError("strains must be non-zero")
         self.relax_structure = relax_structure
+        self.relax_deformed_structures = relax_deformed_structures
         self.fmax = fmax
         if len(self.norm_strains) > 1 and len(self.shear_strains) > 1:
             self.use_equilibrium = use_equilibrium
@@ -83,9 +87,10 @@ class ElasticityCalc(PropCalc):
             structure: The equilibrium structure used for the computation.
         }
         """
-        if self.relax_structure:
+        if self.relax_structure or self.relax_deformed_structures:
             relax_calc = RelaxCalc(self.calculator, fmax=self.fmax, **(self.relax_calc_kwargs or {}))
             structure = relax_calc.calc(structure)["final_structure"]
+            relax_calc.relax_cell = False
 
         deformed_structure_set = DeformedStructureSet(
             structure,
@@ -94,6 +99,9 @@ class ElasticityCalc(PropCalc):
         )
         stresses = []
         for deformed_structure in deformed_structure_set:
+            if self.relax_deformed_structures:
+                deformed_structure = relax_calc.calc(deformed_structure)["final_structure"]
+
             atoms = deformed_structure.to_ase_atoms()
             atoms.calc = self.calculator
             stresses.append(atoms.get_stress(voigt=False))

--- a/tests/test_elasticity.py
+++ b/tests/test_elasticity.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pytest
 from ase.filters import ExpCellFilter
-
 from matcalc.elasticity import ElasticityCalc
 
 if TYPE_CHECKING:
@@ -15,7 +14,8 @@ if TYPE_CHECKING:
     from pymatgen.core import Structure
 
 
-def test_elastic_calc(Li2O: Structure, M3GNetCalc: M3GNetCalculator) -> None:
+@pytest.mark.parametrize("relax_deformed_structures", [False, True])
+def test_elastic_calc(Li2O: Structure, M3GNetCalc: M3GNetCalculator, relax_deformed_structures: bool) -> None:
     """Tests for ElasticCalc class"""
     elast_calc = ElasticityCalc(
         M3GNetCalc,
@@ -23,18 +23,19 @@ def test_elastic_calc(Li2O: Structure, M3GNetCalc: M3GNetCalculator) -> None:
         norm_strains=list(np.linspace(-0.004, 0.004, num=4)),
         shear_strains=list(np.linspace(-0.004, 0.004, num=4)),
         use_equilibrium=True,
+        relax_deformed_structures=relax_deformed_structures,
         relax_calc_kwargs={"cell_filter": ExpCellFilter},
     )
-
     # Test Li2O with equilibrium structure
     results = elast_calc.calc(Li2O)
     assert results["elastic_tensor"].shape == (3, 3, 3, 3)
+    assert results["structure"].lattice.a == pytest.approx(3.2885851104196875, rel=1e-4)
+
     assert results["elastic_tensor"][0][1][1][0] == pytest.approx(0.5014895636122672, rel=1e-3)
     assert results["bulk_modulus_vrh"] == pytest.approx(0.6737897607182401, rel=1e-3)
     assert results["shear_modulus_vrh"] == pytest.approx(0.4179219576918434, rel=1e-3)
     assert results["youngs_modulus"] == pytest.approx(1038959096.5809333, rel=1e-3)
     assert results["residuals_sum"] == pytest.approx(3.8487476828544434e-08, rel=1e-2)
-    assert results["structure"].lattice.a == pytest.approx(3.2885851104196875, rel=1e-4)
 
     # Test Li2O without the equilibrium structure
     elast_calc = ElasticityCalc(


### PR DESCRIPTION
## Summary

Add option to relax atomic positions of strained structures to `ElasticityCalc`.

## Checklist

- [X] Google format doc strings added. Check with `ruff`.
- [X] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
