### PR TITLE
Added support for ORB and GRACE universal calculators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__/
+.coverage*
 *.egg-info
 .DS_Store
 *.o

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,8 @@ dependencies = ["ase>=3.23.0", "joblib", "phonopy", "pymatgen", "numpy<2.0.0", "
 version = "0.0.6"
 
 [project.optional-dependencies]
-models = ["chgnet>=0.3.8", "mace-torch>=0.3.6", "matgl>=1.2.1", "sevenn>=0.9.3", "maml>=2024.6.13", "dgl<=2.1.0", "torch<=2.2.1","nequip>=0.6.1"]
+models = ["chgnet>=0.3.8", "mace-torch>=0.3.6", "matgl>=1.2.1", "sevenn>=0.9.3", "maml>=2024.6.13", "dgl<=2.1.0",
+"torch<=2.2.1", "nequip>=0.6.1", "tensorpotential>=0.5.1", "orb-models>=0.4.1"]
 ci = ["pytest-cov>=4", "pytest-split>=0.8", "pytest>=8", "coverage", "coveralls"]
 phonon = ["seekpath"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ version = "0.0.6"
 
 [project.optional-dependencies]
 models = ["chgnet>=0.3.8", "mace-torch>=0.3.6", "matgl>=1.2.1", "sevenn>=0.9.3", "maml>=2024.6.13", "dgl<=2.1.0",
-"torch<=2.2.1", "nequip>=0.6.1", "tensorpotential>=0.5.1", "orb-models>=0.4.1"]
+"torch<=2.2.1", "nequip>=0.6.1", "tensorpotential>=0.5.1", "orb-models>=0.4.1", "pynanoflann==0.10.0"]
 ci = ["pytest-cov>=4", "pytest-split>=0.8", "pytest>=8", "coverage", "coveralls"]
 phonon = ["seekpath"]
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,7 +8,6 @@ import pytest
 from ase import Atoms
 from ase.calculators.calculator import Calculator
 from ase.optimize.optimize import Optimizer
-
 from matcalc.utils import (
     UNIVERSAL_CALCULATORS,
     VALID_OPTIMIZERS,
@@ -131,6 +130,8 @@ class TestPESCalculator:
 @pytest.mark.skipif(not find_spec("chgnet"), reason="chgnet is not installed")
 @pytest.mark.skipif(not find_spec("mace"), reason="mace is not installed")
 @pytest.mark.skipif(not find_spec("sevenn"), reason="sevenn is not installed")
+@pytest.mark.skipif(not find_spec("tensorpotential"), reason="tensorpotential / grace is not installed")
+@pytest.mark.skipif(not find_spec("orb_models"), reason="orb-models is not installed")
 def test_get_universal_calculator() -> None:
     for name in UNIVERSAL_CALCULATORS:
         calc = get_universal_calculator(name)


### PR DESCRIPTION
## Summary

Major changes:

This PR adds support for two new universal calculators: `ORB` and `GRACE`. This enables the user to work with these universal potentials, extending matcalc's compatibility.

- Added a new branch in `PESCalculator.load_universal` for handling calculators whose names start with "orb" and those starting with "grace" or "tensorpotential".
- Added tests in `tests/test_utils.py` to ensure proper error handling of universal calculators. 
- Restructured the `PESCalculator.load_universal` method to return a single `result: Calculator` to avoid multiple returns (addressing ruff style issues). 
- Updated imports for `sevennet.calculator` in `PESCalculator.load_universal` and `PESCalculator.get_universal`
- Added optional dependencies for `orb` and `tensorpotential` in `pyproject.toml` to support the new calculators.

## Checklist

- [] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
