### PR TITLE
Fix redundant argument passing in Orb calculator initialization

### DIFF
--- a/src/matcalc/utils.py
+++ b/src/matcalc/utils.py
@@ -303,17 +303,17 @@ class PESCalculator(Calculator):
 
             result = SevenNetCalculator(**kwargs)
 
-        elif name.lower().startswith("grace") or name.lower().startswith("tensorpotential"):
+        elif name.lower() == "grace" or name.lower() == "tensorpotential":
             from tensorpotential.calculator.foundation_models import grace_fm
 
             kwargs.setdefault("model", "GRACE-2L-OAM")
             result = grace_fm(**kwargs)
 
-        elif name.lower().startswith("orb"):
+        elif name.lower() == "orb":
             from orb_models.forcefield.calculator import ORBCalculator
             from orb_models.forcefield.pretrained import ORB_PRETRAINED_MODELS
 
-            model = kwargs.get("model", "orb-v2")
+            model = kwargs.pop("model", "orb-v2")
             device = kwargs.get("device", "cpu")
 
             orbff = ORB_PRETRAINED_MODELS[model](device=device)
@@ -376,17 +376,17 @@ def get_universal_calculator(name: str | Calculator, **kwargs: Any) -> Calculato
 
         result = SevenNetCalculator(**kwargs)
 
-    elif name.lower().startswith("grace") or name.lower().startswith("tensorpotential"):
+    elif name.lower() == "grace" or name.lower() == "tensorpotential":
         from tensorpotential.calculator.foundation_models import grace_fm
 
         kwargs.setdefault("model", "GRACE-2L-OAM")
         result = grace_fm(**kwargs)
 
-    elif name.lower().startswith("orb"):
+    elif name.lower() == "orb":
         from orb_models.forcefield.calculator import ORBCalculator
         from orb_models.forcefield.pretrained import ORB_PRETRAINED_MODELS
 
-        model = kwargs.get("model", "orb-v2")
+        model = kwargs.pop("model", "orb-v2")
         device = kwargs.get("device", "cpu")
 
         orbff = ORB_PRETRAINED_MODELS[model](device=device)


### PR DESCRIPTION
## Summary

This PR fixes an issue where the `model` argument was being redundantly passed twice during ORB calculator initialization and again through `kwargs` to `ORBCalculator`. This could potentially lead to argument conflicts.

Minor changes:

- Extracted `model` using `kwargs.pop()` to pop it from `kwargs` before passing to `ORBCalculator`
- Enforced a stronger `name` match for both `Orb` and `Grace` with `name.lower() == "name_of_the_model"` instead of `name.lower().startswith("name_of_the_model")`

## Checklist

- [ ] Google format doc strings added. Check with `ruff`.
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
