### PR TITLE
Add codes, unittests and data for RelaxationBenchmark

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install git+https://github.com/materialsvirtuallab/maml.git
-          pip install -e '.[models,ci,phonon]'
+          pip install -e '.[models,ci,phonon,benchmark]'
       - name: pytest
         run: |
           pytest --cov=matcalc tests --color=yes

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Calculating material properties often requires involved setups of various simula
 goal of MatCalc is to provide a simplified, consistent interface to access these properties with any
 parameterization of the PES.
 
-MatCalc is part of the MatML ecosystem, which includes the [MatGL] (Materials Graph Library) and [maml] (MAterials
+MatCalc is part of the MatML ecosystem, which includes the [MatGL] (Materials Graph Library) and [MAML] (MAterials
 Machine Learning) packages, the [MatPES] (Materials Potential Energy Surface) dataset, and the [MatCalc] (Materials
 Calculator).
 
@@ -134,7 +134,7 @@ initializing the benchmark to limit the number of calculations to do some testin
 A manuscript on `matcalc` is currently in the works. In the meantime, please see [`citation.cff`](citation.cff) or the GitHub
 sidebar for a BibTeX and APA citation.
 
-[maml]: https://materialsvirtuallab.github.io/maml/
+[MAML]: https://materialsvirtuallab.github.io/maml/
 [MatGL]: https://matgl.ai
 [MatPES]: https://matpes.ai
 [MatCalc]: https://matcalc.ai

--- a/benchmark_data/README.md
+++ b/benchmark_data/README.md
@@ -1,3 +1,8 @@
+### [wbm-random-pbe-equilibrium-2025.1.json.gz](wbm-random-pbe-equilibrium-2025.1.json.gz)
+- Relaxe structure, un- and corrected energy of random sampled structures in [WBM] downloaded in Jan 2025
+- Corrects energy using MaterialsProject2020Compatibility.
+- 1000 structures.
+
 ### [mp-binary-pbe-elasticity-2025.1.json.gz](mp-binary-pbe-elasticity-2025.1.json.gz)
 - Elastic moduli of binaries in [Materials Project] downloaded in Jan 2025
 - Excludes K > 500 and G > 500 structures as well as a few bad structures.
@@ -20,5 +25,6 @@
 - Excludes deprecated structures.
 - 9865 structures.
 
+[WBM]: https://figshare.com/articles/dataset/Matbench_Discovery_v1_0_0/22715158
 [Materials Project]: http://materialsproject.org
 [Alexandria Materials Database]: https://alexandria.icams.rub.de

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ models = ["chgnet>=0.3.8", "mace-torch>=0.3.6", "matgl>=1.2.1", "sevenn>=0.9.3",
 "torch<=2.2.1", "nequip>=0.6.1", "tensorpotential>=0.5.1", "orb-models>=0.4.1", "pynanoflann==0.10.0"]
 ci = ["pytest-cov>=4", "pytest-split>=0.8", "pytest>=8", "coverage", "coveralls"]
 phonon = ["seekpath"]
+benchmark = ["matminer>=0.9.3"]
 
 [project.scripts]
 matcalc = "matcalc.cli:main"

--- a/src/matcalc/benchmark.py
+++ b/src/matcalc/benchmark.py
@@ -23,6 +23,7 @@ if typing.TYPE_CHECKING:
 from .config import BENCHMARK_DATA_DIR, BENCHMARK_DATA_DOWNLOAD_URL, BENCHMARK_DATA_URL
 from .elasticity import ElasticityCalc
 from .phonon import PhononCalc
+from .relaxation import RelaxCalc
 from .units import eVA3ToGPa
 
 logger = logging.getLogger(__name__)
@@ -340,6 +341,87 @@ class Benchmark(metaclass=abc.ABCMeta):
 
             results_df = results_df.rename(columns=_rename_property)
         return results_df
+
+
+class RelaxationBenchmark(Benchmark):
+    """
+    Represents a benchmark for evaluating and analyzing relaxation properties of materials.
+    This benchmark utilizes a dataset and provides functionality for property calculation
+    and result processing. The class is designed to work with a predefined framework for
+    benchmarking relaxation properties. The benchmark dataset contains data such as relaxed
+    structures along with additional metadata. This class supports configurability through
+    metadata files, index names, and additional benchmark properties. It relies on external
+    calculators and utility classes for property computations and result handling.
+    """
+
+    def __init__(
+        self,
+        index_name: str = "material_id",
+        benchmark_name: str | Path = "wbm-random-pbe54-equilibrium-2025.1.json.gz",
+        folder_name: str = "default_folder",
+        **kwargs,  # noqa:ANN003
+    ) -> None:
+        """
+        Initializes the RelaxationBenchmark instance with specified benchmark metadata and
+        configuration parameters. It sets up the benchmark with the necessary properties
+        required for relaxation analysis.
+
+        :param index_name: The name of the index used to uniquely identify records in the dataset.
+        :type index_name: str
+        :param benchmark_name: The path or name of the benchmark file that contains the dataset.
+        :type benchmark_name: str | Path
+        :param folder_name: The folder name used for file operations related to structure files.
+        :type folder_name: str
+        :param kwargs: Additional keyword arguments for customization.
+        :type kwargs: dict
+        """
+        self.folder_name = folder_name
+        # Define the expected property from the relaxation calculator.
+        kwargs.setdefault("properties", ("structure",))
+        # Other fields such as the material formula may be included.
+        kwargs.setdefault("other_fields", ("formula",))
+        super().__init__(benchmark_name, index_name=index_name, **kwargs)
+
+    def get_prop_calc(self, calculator: Calculator, **kwargs: typing.Any) -> PropCalc:
+        """
+        Returns a property calculation object for performing relaxation calculations.
+        This method initializes the relaxation calculator using the provided Calculator
+        object and any additional configuration parameters.
+
+        :param calculator: A Calculator object responsible for performing the relaxation calculation.
+        :type calculator: Calculator
+        :param kwargs: Additional keyword arguments used for configuration.
+        :type kwargs: dict
+        :return: An initialized PropCalc object configured for relaxation calculations.
+        :rtype: PropCalc
+        """
+        return RelaxCalc(calculator, **kwargs)
+
+    def process_result(self, result: dict | None, model_name: str) -> dict:
+        """
+        Processes the result dictionary containing final relaxed structures, formats the keys
+        according to the provided model name. If the result is None, default values of
+        NaN are returned for final structures.
+
+        :param result:
+            A dictionary containing the final relaxed structures under the keys
+            'final_structure'. It can also be None to indicate missing elemental_refs.
+        :type result: dict or None
+
+        :param model_name:
+            A string representing the identifier or name of the model. It will be used
+            to format the returned dictionary's keys.
+        :type model_name: str
+
+        :return:
+            A dictionary containing the specific final relaxed structure prefixed by the model name.
+            The values will be NaN if the input result is None.
+
+        :rtype: dict
+        """
+        return {
+            f"structure_{model_name}": (result["final_structure"] if result is not None else float("nan")),
+        }
 
 
 class ElasticityBenchmark(Benchmark):

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -6,11 +6,15 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
+from matminer.featurizers.site import CrystalNNFingerprint
+from matminer.featurizers.structure import SiteStatsFingerprint
+
 from matcalc.benchmark import (
     BenchmarkSuite,
     CheckpointFile,
     ElasticityBenchmark,
     PhononBenchmark,
+    RelaxationBenchmark,
     get_available_benchmarks,
     get_benchmark_data,
 )
@@ -26,12 +30,30 @@ def test_get_benchmark_data() -> None:
         get_benchmark_data("bad_url")
 
 
+def test_relaxation_benchmark(m3gnet_calculator: PESCalculator) -> None:
+    benchmark = RelaxationBenchmark(n_samples=10, perturb_distance=0.1)
+    results = benchmark.run(m3gnet_calculator, "toy")
+    assert len(results) == 10
+
+    ssf = SiteStatsFingerprint(
+        CrystalNNFingerprint.from_preset("ops", distance_cutoffs=None, x_diff_weight=0),
+        stats=("mean", "std_dev", "minimum", "maximum"),
+    )
+
+    distances = np.linalg.norm(
+        np.array([ssf.featurize(s) for s in results["structure_toy"]])
+        - np.array([ssf.featurize(s) for s in results["structure_DFT"]]),
+        axis=1,
+    )
+    assert np.abs(distances).mean() == pytest.approx(0.25, abs=1e-1)
+
+
 def test_elasticity_benchmark(m3gnet_calculator: PESCalculator) -> None:
     benchmark = ElasticityBenchmark(n_samples=10)
     results = benchmark.run(m3gnet_calculator, "toy")
     assert len(results) == 10
     # Compute MAE
-    assert np.abs(results["K_vrh_toy"] - results["K_vrh_DFT"]).mean() == pytest.approx(33, abs=10)
+    assert np.abs(results["K_vrh_toy"] - results["K_vrh_DFT"]).mean() == pytest.approx(38.05842028695785, abs=1e-1)
 
     benchmark = ElasticityBenchmark(benchmark_name="mp-pbe-elasticity-2025.3.json.gz", n_samples=10)
 
@@ -59,7 +81,7 @@ def test_phonon_benchmark(m3gnet_calculator: PESCalculator) -> None:
     benchmark = PhononBenchmark(n_samples=10, write_phonon=False)
     results = benchmark.run(m3gnet_calculator, "toy")
     assert len(results) == 10
-    assert np.abs(results["CV_toy"] - results["CV_DFT"]).mean() == pytest.approx(28, abs=10)
+    assert np.abs(results["CV_toy"] - results["CV_DFT"]).mean() == pytest.approx(27.372493175124838, abs=1e-1)
 
 
 def test_benchmark_suite(m3gnet_calculator: PESCalculator) -> None:


### PR DESCRIPTION
## Summary

This pull request introduces the RelaxationBenchmark module into matcalc project.  

Major changes:

- feature 1: ...
- fix 1: ...

## Todos

If this is work in progress, what else needs to be done?

- feature 2: ...
- fix 2:

## Checklist

- [ ] Google format doc strings added. Check with `ruff`.
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
