### PR TITLE
[WIP] Reproduce benchmarks easily

### DIFF
--- a/benchmark_data/README.md
+++ b/benchmark_data/README.md
@@ -1,16 +1,17 @@
-### [wbm-random-pbe54-equilibrium-2025.1.json.gz](wbm-random-pbe54-equilibrium-2025.1.json.gz)
-- Relaxed structure, un-/corrected energy and un-/corrected formation energy per atom of random sampled structures in [WBM] downloaded in Jan 2025
+### [wbm-random-pbe52-equilibrium-2025.1.json.gz](wbm-random-pbe52-equilibrium-2025.1.json.gz)
+- Relaxed structure, un-/corrected energy and un-/corrected formation energy per atom of random sampled structures in [WBM] downloaded in Jan 2025.
+- Excludes deprecated structures, see [Materials Project Documentation] and [pymatgen#2968] for details.
 - Corrects energy using MaterialsProject2020Compatibility.
-- Uses PBE PAW datasets version 54.
-- 1000 materials.
+- Uses PBE PAW datasets version 52.
+- 972 materials.
 
 ### [mp-binary-pbe-elasticity-2025.1.json.gz](mp-binary-pbe-elasticity-2025.1.json.gz)
-- Elastic moduli of binaries in [Materials Project] downloaded in Jan 2025
+- Elastic moduli of binaries in [Materials Project] downloaded in Jan 2025.
 - Excludes K > 500 and G > 500 structures as well as a few bad structures.
 - 3953 materials.
 
 ### [mp-pbe-elasticity-2025.3.json.gz](mp-pbe-elasticity-2025.3.json.gz)
-- All available elastic moduli in [Materials Project] downloaded in Mar 2025
+- All available elastic moduli in [Materials Project] downloaded in Mar 2025.
 - Excludes K <= 0, K > 500 and G <= 0, G > 500 structures.
 - Excludes H2, N2, O2, F2, Cl2, He, Xe, Ne, Kr, Ar
 - Excludes materials with density < 0.5 (less dense than Li, the least density solid element)
@@ -27,11 +28,13 @@
 - 9865 materials.
 
 ### [wbm-high-energy-states.json.gz](wbm-high-energy-states.json.gz)
-- All available forces in [WBM high energy states] downloaded in Jan 2025
-- Uses PBE PAW datasets version 54.
+- All available forces in [WBM high energy states] downloaded in Jan 2025.
+- Uses PBE PAW datasets version 52.
 - 972 materials, 9308 structures.
 
 [WBM]: https://figshare.com/articles/dataset/Matbench_Discovery_v1_0_0/22715158
 [Materials Project]: http://materialsproject.org
 [Alexandria Materials Database]: https://alexandria.icams.rub.de
 [WBM high energy states]: https://figshare.com/articles/dataset/WBM_high_energy_states/27307776?file=50005317
+[Materials Project Documentation]: https://docs.materialsproject.org/methodology/materials-methodology/calculation-details/gga+u-calculations/pseudopotentials
+[pymatgen#2968]: https://github.com/materialsproject/pymatgen/issues/2968

--- a/src/matcalc/_relaxation.py
+++ b/src/matcalc/_relaxation.py
@@ -200,7 +200,7 @@ class RelaxCalc(PropCalc):
         :rtype: dict
         """
         result = super().calc(structure)
-        structure_in: Structure = result["final_structure"]
+        structure_in: Structure = result["final_structure"].copy()
 
         if self.perturb_distance is not None:
             structure_in = structure_in.perturb(distance=self.perturb_distance)

--- a/src/matcalc/_stability.py
+++ b/src/matcalc/_stability.py
@@ -31,12 +31,12 @@ class EnergeticsCalc(PropCalc):
         evaluations.
     :type calculator: Calculator
     :ivar elemental_refs: Reference data dictionary or identifier for elemental properties.
-        If a string ("MatPES-PBE" or "MatPES-r2SCAN"), loads default references;
+        If a string ("MP-PBE", "MatPES-PBE" or "MatPES-r2SCAN"), loads default references;
         if a dictionary, uses custom provided data.
-    :type elemental_refs: Literal["MatPES-PBE", "MatPES-r2SCAN"] | dict
-    :ivar use_dft_gs_reference: Whether to use DFT ground state data for energy computations
+    :type elemental_refs: Literal["MP-PBE", "MatPES-PBE", "MatPES-r2SCAN"] | dict
+    :ivar use_gs_reference: Whether to use DFT ground state data for energy computations
         when referencing elemental properties.
-    :type use_dft_gs_reference: bool
+    :type use_gs_reference: bool
     :ivar relax_structure: Specifies whether to relax the input structures before property
         calculations. If True, relaxation is applied.
     :type relax_structure: bool
@@ -49,8 +49,11 @@ class EnergeticsCalc(PropCalc):
         self,
         calculator: Calculator | str,
         *,
-        elemental_refs: Literal["MatPES-PBE", "MatPES-r2SCAN"] | dict = "MatPES-PBE",
-        use_dft_gs_reference: bool = False,
+        elemental_refs: Literal["MP-PBE", "MatPES-PBE", "MatPES-r2SCAN"] | dict = "MatPES-PBE",
+        fmax: float = 0.1,
+        optimizer: str = "FIRE",
+        perturb_distance: float | None = None,
+        use_gs_reference: bool = False,
         relax_structure: bool = True,
         relax_calc_kwargs: dict | None = None,
     ) -> None:
@@ -68,12 +71,18 @@ class EnergeticsCalc(PropCalc):
             calculations. If string is provided, the corresponding universal calculator is loaded.
         :type calculator: Calculator | str
         :param elemental_refs: Specifies the elemental references to be used. It can either be
-            a predefined string identifier ("MatPES-PBE", "MatPES-r2SCAN") or a dictionary
+            a predefined string identifier ("MP-PBE", "MatPES-PBE", "MatPES-r2SCAN") or a dictionary
             mapping elements to their energy references.
-        :type elemental_refs: Literal["MatPES-PBE", "MatPES-r2SCAN"] | dict
-        :param use_dft_gs_reference: Determines whether to use DFT ground state
-            energy as a reference. Defaults to False.
-        :type use_dft_gs_reference: bool
+        :type elemental_refs: Literal["MP-PBE", "MatPES-PBE", "MatPES-r2SCAN"] | dict
+        :ivar fmax: Force tolerance for convergence (eV/Å).
+        :type fmax: float
+        :ivar optimizer: Algorithm for performing the optimization.
+        :type optimizer: Optimizer | str
+        :ivar perturb_distance: Distance (Å) for random perturbation to break symmetry.
+        :type perturb_distance: float | None
+        :param use_gs_reference: Determines whether to use ground state energy as a reference.
+            Defaults to False.
+        :type use_gs_reference: bool
         :param relax_structure: Specifies if the structure should be relaxed before
             proceeding with calculations. Defaults to True.
         :type relax_structure: bool
@@ -82,11 +91,14 @@ class EnergeticsCalc(PropCalc):
         :type relax_calc_kwargs: dict | None
         """
         self.calculator = calculator  # type: ignore[assignment]
+        self.fmax = fmax
+        self.optimizer = optimizer
+        self.perturb_distance = perturb_distance
         if isinstance(elemental_refs, str):
             self.elemental_refs = loadfn(ELEMENTAL_REFS_DIR / f"{elemental_refs}-Element-Refs.json.gz")
         else:
             self.elemental_refs = elemental_refs
-        self.use_dft_gs_reference = use_dft_gs_reference
+        self.use_gs_reference = use_gs_reference
         self.relax_structure = relax_structure
         self.relax_calc_kwargs = relax_calc_kwargs
 
@@ -106,39 +118,50 @@ class EnergeticsCalc(PropCalc):
         """
         result = super().calc(structure)
         structure_in: Structure = result["final_structure"]
+
         relaxer = RelaxCalc(
             self.calculator,
+            fmax=self.fmax,
+            optimizer=self.optimizer,
+            perturb_distance=self.perturb_distance,
             **(self.relax_calc_kwargs or {}),
         )
         if self.relax_structure:
             result |= relaxer.calc(structure_in)
             structure_in = result["final_structure"]
-
-        atoms = AseAtomsAdaptor.get_atoms(structure_in)
-        atoms.calc = self.calculator
-        energy = atoms.get_potential_energy()
+            energy = result["energy"]
+        else:
+            atoms = AseAtomsAdaptor.get_atoms(structure_in)
+            atoms.calc = self.calculator
+            energy = atoms.get_potential_energy()
         nsites = len(structure_in)
 
         def get_gs_energy(el: Element | Species) -> float:
             """
-            Returns the ground state energy for a given element. If use_dft_gs_reference is True, we use the
+            Returns the ground state energy for a given element. If use_gs_reference is True, we use the
             pre-computed DFT energy.
 
             :param el: Element symbol.
             :return: Energy per atom.
             """
-            if self.use_dft_gs_reference:
-                return self.elemental_refs[el.symbol]["energy_per_atom"]
+            if self.use_gs_reference:
+                gs_energy = self.elemental_refs[el.symbol]["energy_per_atom"]
+                return min(gs_energy) if isinstance(gs_energy, list) else gs_energy
 
-            eldata = relaxer.calc(self.elemental_refs[el.symbol]["structure"])
-            return eldata["energy"] / eldata["final_structure"].num_sites
+            relaxer.perturb_distance = None
+            structure = self.elemental_refs[el.symbol]["structure"]
+            structure_list = [structure] if not isinstance(structure, list) else structure
+            return min(r["energy"] / r["final_structure"].num_sites for r in list(relaxer.calc_many(structure_list)))
 
         comp = structure_in.composition
         e_form = energy - sum([get_gs_energy(el) * amt for el, amt in comp.items()])
 
-        e_coh = energy - sum([self.elemental_refs[el.symbol]["energy_atomic"] * amt for el, amt in comp.items()])
+        try:
+            e_coh = energy - sum([self.elemental_refs[el.symbol]["energy_atomic"] * amt for el, amt in comp.items()])
+            result = result | {"cohesive_energy_per_atom": e_coh / nsites}
+        except KeyError:
+            result = result | {"cohesive_energy_per_atom": None}
 
         return result | {
             "formation_energy_per_atom": e_form / nsites,
-            "cohesive_energy_per_atom": e_coh / nsites,
         }

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -4,6 +4,8 @@ import itertools
 import os
 from typing import TYPE_CHECKING
 
+from pathlib import Path
+
 import numpy as np
 import pytest
 
@@ -22,6 +24,11 @@ if TYPE_CHECKING:
     from matgl.ext.ase import PESCalculator
 
 
+def test_available_benchmarks() -> None:
+    assert "mp-binary-pbe-elasticity-2025.1.json.gz" in get_available_benchmarks()
+    assert "alexandria-binary-pbe-phonon-2025.1.json.gz" in get_available_benchmarks()
+
+
 def test_get_benchmark_data() -> None:
     d = get_benchmark_data("mp-pbe-elasticity-2025.3.json.gz")
     assert len(d) > 10000
@@ -30,15 +37,15 @@ def test_get_benchmark_data() -> None:
 
 
 def test_equilibrium_benchmark(matpes_calculator: PESCalculator) -> None:
-    benchmark = EquilibriumBenchmark(n_samples=10)
+    benchmark = EquilibriumBenchmark(seed=1, n_samples=2)
     results = benchmark.run(matpes_calculator, "toy")
-    assert len(results) == 10
-    assert results["d_toy"].mean() == pytest.approx(0.1, abs=1e-1)
-    assert np.abs(results["Eform_toy"] - results["Eform_DFT"]).mean() == pytest.approx(0.045, abs=1e-2)
+    assert len(results) == 2
+    assert results["d_toy"].mean() == pytest.approx(0.2294704733560756, abs=1e-1)
+    assert np.abs(results["Eform_toy"] - results["Eform_DFT"]).mean() == pytest.approx(0.05122194169085273, abs=1e-2)
 
 
 def test_elasticity_benchmark(m3gnet_calculator: PESCalculator) -> None:
-    benchmark = ElasticityBenchmark(n_samples=10)
+    benchmark = ElasticityBenchmark(seed=101, n_samples=3)
     chkpt_file = "checkpoint.json"
 
     results = benchmark.run(
@@ -47,9 +54,9 @@ def test_elasticity_benchmark(m3gnet_calculator: PESCalculator) -> None:
 
     # Makes sure that checkpoint file is deleted upon completion.
     assert not os.path.exists(chkpt_file)
-    assert len(results) == 10
+    assert len(results) == 3
     # Compute MAE
-    assert np.abs(results["K_vrh_toy"] - results["K_vrh_DFT"]).mean() == pytest.approx(38.05842028695785, abs=1e-1)
+    assert np.abs(results["K_vrh_toy"] - results["K_vrh_DFT"]).mean() == pytest.approx(20.827423861035843, rel=1e-1)
 
     benchmark = ElasticityBenchmark(benchmark_name="mp-pbe-elasticity-2025.3.json.gz", n_samples=10)
 
@@ -73,28 +80,28 @@ def test_elasticity_benchmark(m3gnet_calculator: PESCalculator) -> None:
 
 
 def test_phonon_benchmark(m3gnet_calculator: PESCalculator) -> None:
-    benchmark = PhononBenchmark(n_samples=10)
+    benchmark = PhononBenchmark(seed=0, n_samples=3)
     results = benchmark.run(m3gnet_calculator, "toy")
-    assert len(results) == 10
-    assert np.abs(results["CV_toy"] - results["CV_DFT"]).mean() == pytest.approx(27.372493175124838, abs=1e-1)
+    assert len(results) == 3
+    assert np.abs(results["CV_toy"] - results["CV_DFT"]).mean() == pytest.approx(17.91411211019882, abs=1e-1)
 
 
 def test_softening_benchmark(m3gnet_calculator: PESCalculator) -> None:
-    benchmark = SofteningBenchmark(n_samples=3)
-    results = benchmark.run(m3gnet_calculator, "toy", checkpoint_freq=1, checkpoint_file="checkpoint.json")
+    benchmark = SofteningBenchmark(seed=42, n_samples=3)
+    results = benchmark.run(m3gnet_calculator, "toy")
     assert len(results) == 3
     assert "softening_scale_toy" in results
 
 
 def test_benchmark_suite(m3gnet_calculator: PESCalculator) -> None:
-    elasticity_benchmark = ElasticityBenchmark(n_samples=2, benchmark_name="mp-pbe-elasticity-2025.3.json.gz")
+    elasticity_benchmark = ElasticityBenchmark(seed=0, n_samples=2, benchmark_name="mp-pbe-elasticity-2025.3.json.gz")
     elasticity_benchmark.run(
         m3gnet_calculator,
         "toy1",
         checkpoint_freq=1,
         delete_checkpoint_on_finish=False,
     )
-    phonon_benchmark = PhononBenchmark(n_samples=2)
+    phonon_benchmark = PhononBenchmark(seed=0, n_samples=2)
     suite = BenchmarkSuite(benchmarks=[elasticity_benchmark, phonon_benchmark])
     results = suite.run(
         {"toy1": m3gnet_calculator, "toy2": m3gnet_calculator}, checkpoint_freq=1, delete_checkpoint_on_finish=False
@@ -109,8 +116,3 @@ def test_benchmark_suite(m3gnet_calculator: PESCalculator) -> None:
     assert "G_vrh_toy2" in results[0].columns
     assert "CV_toy1" in results[1].columns
     assert "CV_toy2" in results[1].columns
-
-
-def test_available_benchmarks() -> None:
-    assert "mp-binary-pbe-elasticity-2025.1.json.gz" in get_available_benchmarks()
-    assert "alexandria-binary-pbe-phonon-2025.1.json.gz" in get_available_benchmarks()

--- a/tests/test_stability.py
+++ b/tests/test_stability.py
@@ -29,7 +29,7 @@ def test_energetics_calc(
     # each O atom, which accounts almost entirely for the difference between this predicted formation energy and the
     # MP calculated value of -2.0 eV.
 
-    result = EnergeticsCalc(matpes_calculator, use_dft_gs_reference=True).calc(Li2O)
+    result = EnergeticsCalc(matpes_calculator, use_gs_reference=True).calc(Li2O)
     for key in (
         "final_structure",
         "formation_energy_per_atom",


### PR DESCRIPTION
## Summary

This pull request enhances our property calculating and benchmarking framework with several updates to improve accuracy, consistency, and performance:
Major changes:

- Corrects the PAW dataset version used in WBM dataset from 54 to 52.  
- Uses the copy of the input to avoid perturbating the original structure in `RelaxCalc`.
- Modifies `EnergeticsCalc` to compute reference energies without perturbing the elemental reference structures and selects the minimum as reference energies when multiple entries corresponding to one element.  
- Set the `fmax` to 0.05 for all `Benchmark` class to match the setting we used in the publications.  
- Optimizes `EquilibriumBenchmark` by precomputing each element’s ground‑state data once up front, greatly reducing redundant relaxations.

## Results Reproducing
Now, use the codes provided in the [issue#64](https://github.com/materialsvirtuallab/matcalc/issues/64) for M3GNet, CHGNet and TensorNet. The results I obtained are:

> M3GNet:
> d_MAE: 0.42, Ef_MAE: 0.109
> CHGNet:
> d_MAE: 0.43, Ef_MAE 0.080
> TensorNet:
> d_MAE: 0.37, Ef_MAE: 0.081

These numbers closely match what’s shown on the official website (https://matpes.ai/benchmarks).
Note: The perturbations applied are random for every run, small run‐to‐run variations are expected but do not affect overall comparisons..

## Checklist

- [ ] Google format doc strings added. Check with `ruff`.
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
