### PR TITLE
Update OCPCalculator with the newer FairChemCalculator

### DIFF
--- a/src/matcalc/utils.py
+++ b/src/matcalc/utils.py
@@ -403,14 +403,14 @@ class PESCalculator(Calculator):
             result = MatterSimCalculator(**kwargs)
 
         elif name.lower() == "fairchem":  # pragma: no cover
-            from fairchem.core import OCPCalculator
+            from fairchem.core import pretrained_mlip, FAIRChemCalculator
 
-            # Technically, this supports all models that are in fairchem,
-            # not just equiformer.
-            kwargs.setdefault("model_name", "EquiformerV2-31M-S2EF-OC20-All+MD")
-            kwargs.setdefault("local_cache", "./pretrained_models")
-            result = OCPCalculator(**kwargs)
-
+            device = kwargs.pop("device", "cpu")
+            model = kwargs.pop("model", "uma-s-1")
+            task_name = kwargs.pop("task_name", "omat")
+            predictor = pretrained_mlip.get_predict_unit(model, device=device)
+            result = FAIRChemCalculator(predictor, task_name=task_name, **kwargs)
+            
         elif name.lower() == "petmad":  # pragma: no cover
             from pet_mad.calculator import PETMADCalculator
 

--- a/src/matcalc/utils.py
+++ b/src/matcalc/utils.py
@@ -403,14 +403,14 @@ class PESCalculator(Calculator):
             result = MatterSimCalculator(**kwargs)
 
         elif name.lower() == "fairchem":  # pragma: no cover
-            from fairchem.core import pretrained_mlip, FAIRChemCalculator
+            from fairchem.core import FAIRChemCalculator, pretrained_mlip
 
             device = kwargs.pop("device", "cpu")
             model = kwargs.pop("model", "uma-s-1")
             task_name = kwargs.pop("task_name", "omat")
             predictor = pretrained_mlip.get_predict_unit(model, device=device)
             result = FAIRChemCalculator(predictor, task_name=task_name, **kwargs)
-            
+
         elif name.lower() == "petmad":  # pragma: no cover
             from pet_mad.calculator import PETMADCalculator
 


### PR DESCRIPTION
## Summary
Fairchem=2.2 retired the previous `OCPCalculator` and replaced it with a newer `FairChemCalculator` which can also support the latest UMA models. This PR reflects those changes.
 
Major changes:

- fix 1: Replaced older `OCPCalculator` with the newer `FairChemCalculator`

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
