### PR TITLE
Add IsotropicMTKNPT to `_md.py`

### DIFF
--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
         ("npt_inhomogeneous", -10.74737),
         ("npt_berendsen", -10.74714),
         ("npt_nose_hoover", -10.86120),
-        ("npt_isotropic_mtk", -10.86120),
+        ("npt_isotropic_mtk", -10.76271),
     ],
 )
 def test_md_calc(
@@ -47,8 +47,6 @@ def test_md_calc(
         calculator=matpes_calculator,
         ensemble=ensemble,
         temperature=300,
-        taut=0.1,
-        taup=0.1,
         steps=10,
         frames=5,
         compressibility_au=1,

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
         ("npt_inhomogeneous", -10.74737),
         ("npt_berendsen", -10.74714),
         ("npt_nose_hoover", -10.86120),
+        ("npt_isotropic_mtk", -10.86120),
     ],
 )
 def test_md_calc(

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -19,16 +19,16 @@ if TYPE_CHECKING:
 @pytest.mark.parametrize(
     ("ensemble", "expected_energy"),
     [
-        ("nve", -10.74606),
-        ("nvt", -10.81289),
-        ("nvt_berendsen", -10.73112),
-        ("nvt_langevin", -10.78238),
-        ("nvt_andersen", -10.82750),
-        ("nvt_bussi", -10.77756),
-        ("npt_inhomogeneous", -10.74737),
-        ("npt_berendsen", -10.74714),
-        ("npt_nose_hoover", -10.86120),
-        ("npt_isotropic_mtk", -10.76271),
+        ("nve", -10.839367595419139),
+        ("nvt", -10.752140577997002),
+        ("nvt_berendsen", -10.79344712397928),
+        ("nvt_langevin", -10.719885845311552),
+        ("nvt_andersen", -10.838280482248559),
+        ("nvt_bussi", -10.83345229703825),
+        ("npt_inhomogeneous", -10.778117238180538),
+        ("npt_berendsen", -10.797141692994748),
+        ("npt_nose_hoover", -10.773028687488921),
+        ("npt_isotropic_mtk", -10.817933454243002),
     ],
 )
 def test_md_calc(
@@ -62,7 +62,7 @@ def test_md_calc(
     assert "kinetic_energy" in results
     assert "total_energy" in results
 
-    assert results["total_energy"] == pytest.approx(expected_energy, rel=1e-1)
+    assert results["total_energy"] == pytest.approx(expected_energy, rel=1e-2)
 
     energies = np.array(results["trajectory"].total_energies)
 


### PR DESCRIPTION
## Summary

This PR adds support for IsotropicMTKNPT simulations. Closes #87.

In doing so, I have added the `"npt_isotropic_mtk"` option to the list of supported `ensemble`s. I have also added keyword arguments for `tchain`, `pchain`, `tloop`, and `ploop`.

A unit test has been added for the `npt_isotropic_mtk` ensemble. Note that I updated the test by relying on the default values of `taut` and `taup` instead of 0.1 for both, as the latter results in a `nan` with `npt_isotropic_mtk`. Since it is usually the case that `taut` is 100 * timestep and `taup` * 1000 timestep, this is perhaps not too surprising. 

## Checklist

- [X] Google format doc strings added. Check with `ruff`.
- [X] Type annotations included. Check with `mypy`.
- [X] Tests added for new features/fixes.
- [X] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
