### PR TITLE
ruff format fixed

### DIFF
--- a/src/matcalc/utils.py
+++ b/src/matcalc/utils.py
@@ -46,8 +46,9 @@ try:
     # Auto-load all available PES models from matgl if installed.
     import matgl
 
-    _universal_calculators += [m for m in matgl.get_available_pretrained_models()
-                               if "PES" in m and "ANI-1x-Subset-PES" not in m]
+    _universal_calculators += [
+        m for m in matgl.get_available_pretrained_models() if "PES" in m and "ANI-1x-Subset-PES" not in m
+    ]
     _universal_calculators = sorted(set(_universal_calculators))
 except Exception:  # noqa: BLE001
     warnings.warn("Unable to get pre-trained MatGL universal calculators.", stacklevel=1)


### PR DESCRIPTION
## Summary
ruff format fixed

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
