### PR TITLE
[WIP] Make it possible to set COM momentum and rotation to zero

### DIFF
--- a/src/matcalc/_md.py
+++ b/src/matcalc/_md.py
@@ -82,6 +82,8 @@ class MDCalc(PropCalc):
         optimizer: str = "FIRE",
         frames: int | None = None,
         relax_calc_kwargs: dict | None = None,
+        set_com_stationary: bool = False,
+        set_zero_rotation: bool = False,
     ) -> None:
         """
         Initializes an MDCalc instance with the specified simulation parameters and relaxation settings.
@@ -128,6 +130,10 @@ class MDCalc(PropCalc):
             returned, i.e., frames = steps.
             relax_calc_kwargs (dict | None): Additional keyword arguments for the relaxation calculation.
                 Default to None.
+            set_com_stationary (bool): Whether to set the center-of-mass momentum to zero.
+                Default to False.
+            set_zero_rotation (bool): Whether to set the total angular momentum to zero.
+                Default to False.
         """
         self.calculator = calculator
         self.ensemble = ensemble
@@ -393,6 +399,12 @@ class MDCalc(PropCalc):
         # Initialize the atomic velocities based on the Maxwell-Boltzmann distribution
         # at the specified temperature, ensuring proper kinetic energy.
         MaxwellBoltzmannDistribution(atoms, temperature_K=self.temperature)
+
+        if self.set_com_stationary:
+            Stationary(atoms)
+
+        if self.set_zero_rotation:
+            ZeroRotation(atoms)
 
         # Initialize the molecular dynamics (MD) simulation and set up the simulation parameters.
         md = self._initialize_md(atoms)


### PR DESCRIPTION
## Summary

This PR adds support for setting the center-of-mass momentum to zero or angular momenta to zero following the creation of the Maxwell-Boltzmann distribution. Without these features, you can get drift of the center-of-mass like shown below:

![test](https://github.com/user-attachments/assets/4f36bd07-6393-4ba8-82b9-2ae103d05f7e)

## Checklist

- [X] Google format doc strings added. Check with `ruff`.
- [X] Type annotations included. Check with `mypy`.
- [] Tests added for new features/fixes.
- [X] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
