### PR TITLE
fix: add `required-environments` to enable linux install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,12 @@ conflicts = [
       { extra = "mattersim" },
     ],
 ]
+required-environments = [
+    "sys_platform == 'linux'",
+    "sys_platform == 'darwin' and platform_machine == 'x86_64'",
+    "sys_platform == 'darwin' and platform_machine == 'arm64'",
+]
+
 
 [tool.ruff]
 line-length = 120

--- a/uv.lock
+++ b/uv.lock
@@ -19,6 +19,11 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux'",
 ]
+required-markers = [
+    "sys_platform == 'linux'",
+    "platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "platform_machine == 'arm64' and sys_platform == 'darwin'",
+]
 conflicts = [[
     { package = "matcalc", extra = "fairchem" },
     { package = "matcalc", extra = "mace" },
@@ -245,16 +250,16 @@ wheels = [
 
 [[package]]
 name = "ase"
-version = "3.25.0"
+version = "3.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "matplotlib" },
     { name = "numpy" },
     { name = "scipy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e8/a1/5735ced2f159979f5b27c4083126b7796a5750cee6f027864e59818a5b76/ase-3.25.0.tar.gz", hash = "sha256:374cf8ca9fe588f05d6e856da3c9c17ef262dc968027b231d449334140c962c2", size = 2400055, upload-time = "2025-04-11T17:14:39.975Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/33/2ffa44950267450f6a5cdb711c68e12d0d72d626e246e5897e3bada7bac6/ase-3.26.0.tar.gz", hash = "sha256:a071a355775b0a8062d23e9266e9d811b19d9f6d9ec5215e8032f7d93dc65075", size = 2405567, upload-time = "2025-08-12T13:06:55.589Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/f5/007d993fcf3b051acb304d5402e0bd103fd20816b47dee9531bdbfb3aa0c/ase-3.25.0-py3-none-any.whl", hash = "sha256:f9a5295e1154da355af04726d001fa76a311c076616d98e49cd9f34fc3afe188", size = 2951559, upload-time = "2025-04-11T17:14:37.617Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/f0/6e52d797bee63530f4b778cb4cbb3a01970f104197c364a8ff51bc9f5a21/ase-3.26.0-py3-none-any.whl", hash = "sha256:77fd0e609bd3868006d4bb3bb95cdc4081d9e292ac84f6c9fb564b5751d2689e", size = 2946787, upload-time = "2025-08-12T13:06:53.316Z" },
 ]
 
 [[package]]
@@ -1060,17 +1065,65 @@ wheels = [
 
 [[package]]
 name = "dgl"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+]
+dependencies = [
+    { name = "networkx", marker = "sys_platform == 'linux' or (extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim')" },
+    { name = "numpy", marker = "sys_platform == 'linux' or (extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim')" },
+    { name = "psutil", marker = "sys_platform == 'linux' or (extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim')" },
+    { name = "requests", marker = "sys_platform == 'linux' or (extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim')" },
+    { name = "scipy", marker = "sys_platform == 'linux' or (extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim')" },
+    { name = "torchdata", marker = "sys_platform == 'linux' or (extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim')" },
+    { name = "tqdm", marker = "sys_platform == 'linux' or (extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/2d/c0a40c0d78a8e9c0c43e7f6e4aebebb39c8bf0f80380db2c1f1ba9f3bdfa/dgl-2.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ff74c7119cb1e87c1b06293eba8c22725594517062e74659b1a8636134b16974", size = 6889468, upload-time = "2024-03-05T07:16:21.004Z" },
+    { url = "https://files.pythonhosted.org/packages/89/19/08b77e50de7beb9c011905167ab38ecee759a796447ed7ad466484eafb53/dgl-2.1.0-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:1fda987e01987d655e9a2b16281e1f31759bd5088ce08785422055c71abc0298", size = 7464359, upload-time = "2024-03-05T07:16:24.216Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/45/44fea6e5228602f5d6ad8b4f5a377f5cf5cb5cb6444d9e7cd99150f13fa2/dgl-2.1.0-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:336e5aed294b9f2f398be332caa0b256e6386e5a6a3a25dfe0715a161e6c4f94", size = 8548990, upload-time = "2024-03-05T07:16:26.655Z" },
+    { url = "https://files.pythonhosted.org/packages/73/72/6bc97419cf8fa1e11420c674fafa3c03e4df9d91bfd8fd802011b5741ce9/dgl-2.1.0-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:65f5ae94c4c88433fc4524ab8c431494cfddd8100181d5de6df4ed08aa41d14d", size = 7430720, upload-time = "2024-03-05T07:16:29.505Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/15/6571516b8bdd2f8db29e2739bca7afcd6cf75179b156f72f159a0986c9ed/dgl-2.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:fc7ea52fa9d42bf507ccf3b43b6d05c5ee3fce4c614033833ef08aa089b89bc6", size = 6872096, upload-time = "2024-03-05T07:16:31.298Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/48/c62028815d8f1fadff4dc83bbb9bd2e5aa113835bbe14dad92b716d1fd05/dgl-2.1.0-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:994a7dd11d6da251438762e9fb6657ee2bd9715300aa1f11143a0d61be620ec5", size = 7331725, upload-time = "2024-03-05T07:16:33.862Z" },
+    { url = "https://files.pythonhosted.org/packages/15/0b/07c479b28b2b36cbc49f5fa78156fc77f918a4bf5927c9409947d2d3d68d/dgl-2.1.0-cp311-cp311-manylinux1_x86_64.whl", hash = "sha256:050af2b3d54f158be67ae222dbf786b2b35e5d5d6a29fbf2a81b854e99f13adf", size = 8561303, upload-time = "2024-03-05T07:16:36.714Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/28/173f36cae067f17ddb45faa4ee91ca5e31efb194edba667761b53b2e1baf/dgl-2.1.0-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:3b54764b7fae40d41eb936bbfe9f254b1b11ed4993d8c61be8e81d09d955f72a", size = 7443820, upload-time = "2024-03-05T07:16:40.077Z" },
+    { url = "https://files.pythonhosted.org/packages/22/62/6868d769988961d8bb482325c4a6ba3c0007d49ba96d11c79d8c33d016c9/dgl-2.1.0-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:c0abdc0bf4407f67d1df45b9acd5f8017d26ef13aebaaec973a35905cb70e4ef", size = 7331721, upload-time = "2024-03-05T07:16:43.233Z" },
+    { url = "https://files.pythonhosted.org/packages/24/5b/40e7802b5bfda663408841e3f4f5ccdb97ceefae8011f47be22b81c40275/dgl-2.1.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:ffebbfbbc2278861601fa44b533e3b4a6f21bbfd742542932cb3af0c7621cffc", size = 6872090, upload-time = "2024-03-05T07:16:45.76Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/78/84bc05dd88db7a15eb32798d538cb8fd5e4e4c6fa966a650844a43c7beb5/dgl-2.1.0-cp312-cp312-manylinux1_x86_64.whl", hash = "sha256:af9b5974d667d11b9b2dc153981241c248a314c1a54880d4a2af12a00470b78d", size = 8551552, upload-time = "2024-03-05T07:16:47.994Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/d7/910035a1501d13b7fd7d90c5333ecc17ff7ebfa43195e2f856a0140d22a4/dgl-2.1.0-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:0f8605418e71191f7a4b43a5a6597e655512c7a48171ac042993d77c676f3092", size = 7435020, upload-time = "2024-03-05T07:16:50.847Z" },
+]
+
+[[package]]
+name = "dgl"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and sys_platform != 'linux' and sys_platform != 'win32'",
+]
 dependencies = [
-    { name = "networkx" },
-    { name = "numpy" },
-    { name = "pandas" },
-    { name = "psutil" },
-    { name = "requests" },
-    { name = "scipy" },
-    { name = "torchdata" },
-    { name = "tqdm" },
+    { name = "networkx", marker = "sys_platform != 'linux' or (extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim')" },
+    { name = "numpy", marker = "sys_platform != 'linux' or (extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim')" },
+    { name = "pandas", marker = "sys_platform != 'linux' or (extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim')" },
+    { name = "psutil", marker = "sys_platform != 'linux' or (extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim')" },
+    { name = "requests", marker = "sys_platform != 'linux' or (extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim')" },
+    { name = "scipy", marker = "sys_platform != 'linux' or (extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim')" },
+    { name = "torchdata", marker = "sys_platform != 'linux' or (extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim')" },
+    { name = "tqdm", marker = "sys_platform != 'linux' or (extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/90/09/522060351a971927ae5db1b265219055a836f0c2da81079fe4d68e2c8a45/dgl-2.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:eece51bbc2b7f951c78b2e53cb5ac7e645f30ea142729bb613a9c9e3ef9ca338", size = 7400188, upload-time = "2024-05-08T07:16:07.462Z" },
@@ -2862,7 +2915,7 @@ test-models = [
 
 [package.metadata]
 requires-dist = [
-    { name = "ase", specifier = ">=3.25.0" },
+    { name = "ase", specifier = ">=3.26.0" },
     { name = "codecov-cli", marker = "extra == 'ci'", specifier = ">=10.3.0" },
     { name = "coverage", marker = "extra == 'ci'", specifier = ">=7.7.1" },
     { name = "coveralls", marker = "extra == 'ci'", specifier = ">=4.0.1" },
@@ -2941,7 +2994,8 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ase" },
     { name = "boto3" },
-    { name = "dgl" },
+    { name = "dgl", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux' or (extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim')" },
+    { name = "dgl", version = "2.2.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' or (extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim')" },
     { name = "fsspec" },
     { name = "lightning" },
     { name = "numpy" },
@@ -3647,7 +3701,7 @@ name = "nvidia-cudnn-cu12"
 version = "8.9.2.26"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "platform_machine != 'aarch64' and sys_platform == 'linux'" },
+    { name = "nvidia-cublas-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (platform_machine == 'aarch64' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (platform_machine == 'aarch64' and extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ff/74/a2e2be7fb83aaedec84f391f082cf765dfb635e7caa9b49065f73e4835d8/nvidia_cudnn_cu12-8.9.2.26-py3-none-manylinux1_x86_64.whl", hash = "sha256:5ccb288774fdfb07a7e7025ffec286971c06d8d7b4fb162525334616d7629ff9", size = 731725872, upload-time = "2023-06-01T19:24:57.328Z" },
@@ -3676,9 +3730,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.4.5.107"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "platform_machine != 'aarch64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "platform_machine != 'aarch64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine != 'aarch64' and sys_platform == 'linux'" },
+    { name = "nvidia-cublas-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (platform_machine == 'aarch64' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (platform_machine == 'aarch64' and extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim')" },
+    { name = "nvidia-cusparse-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (platform_machine == 'aarch64' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (platform_machine == 'aarch64' and extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (platform_machine == 'aarch64' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (platform_machine == 'aarch64' and extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/1d/8de1e5c67099015c834315e333911273a8c6aaba78923dd1d1e25fc5f217/nvidia_cusolver_cu12-11.4.5.107-py3-none-manylinux1_x86_64.whl", hash = "sha256:8a7ec542f0412294b15072fa7dab71d31334014a69f953004ea7a118206fe0dd", size = 124161928, upload-time = "2023-04-19T15:51:25.781Z" },
@@ -3690,7 +3744,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.1.0.106"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine != 'aarch64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (platform_machine == 'aarch64' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (platform_machine == 'aarch64' and extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/65/5b/cfaeebf25cd9fdec14338ccb16f6b2c4c7fa9163aefcf057d86b9cc248bb/nvidia_cusparse_cu12-12.1.0.106-py3-none-manylinux1_x86_64.whl", hash = "sha256:f3b50f42cf363f86ab21f720998517a659a48131e8d538dc02f8768237bd884c", size = 195958278, upload-time = "2023-04-19T15:51:49.939Z" },
@@ -6288,19 +6342,19 @@ dependencies = [
     { name = "fsspec" },
     { name = "jinja2" },
     { name = "networkx" },
-    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cublas-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (platform_machine != 'x86_64' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (platform_machine != 'x86_64' and extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim')" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (platform_machine != 'x86_64' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (platform_machine != 'x86_64' and extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim')" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (platform_machine != 'x86_64' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (platform_machine != 'x86_64' and extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim')" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (platform_machine != 'x86_64' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (platform_machine != 'x86_64' and extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim')" },
+    { name = "nvidia-cudnn-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (platform_machine != 'x86_64' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (platform_machine != 'x86_64' and extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim')" },
+    { name = "nvidia-cufft-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (platform_machine != 'x86_64' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (platform_machine != 'x86_64' and extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim')" },
+    { name = "nvidia-curand-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (platform_machine != 'x86_64' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (platform_machine != 'x86_64' and extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim')" },
+    { name = "nvidia-cusolver-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (platform_machine != 'x86_64' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (platform_machine != 'x86_64' and extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim')" },
+    { name = "nvidia-cusparse-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (platform_machine != 'x86_64' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (platform_machine != 'x86_64' and extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim')" },
+    { name = "nvidia-nccl-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (platform_machine != 'x86_64' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (platform_machine != 'x86_64' and extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim')" },
+    { name = "nvidia-nvtx-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (platform_machine != 'x86_64' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (platform_machine != 'x86_64' and extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim')" },
     { name = "sympy" },
-    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "triton", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (platform_machine != 'x86_64' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (platform_machine != 'x86_64' and extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim')" },
     { name = "typing-extensions" },
 ]
 wheels = [
@@ -6420,7 +6474,7 @@ name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
 wheels = [
@@ -6483,7 +6537,7 @@ name = "triton"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "filelock", marker = "platform_machine != 'aarch64' and sys_platform == 'linux'" },
+    { name = "filelock", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (platform_machine == 'aarch64' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (platform_machine == 'aarch64' and extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mace') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-fairchem' and extra == 'extra-7-matcalc-mattersim') or (sys_platform != 'linux' and extra == 'extra-7-matcalc-mace' and extra == 'extra-7-matcalc-mattersim')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/95/05/ed974ce87fe8c8843855daa2136b3409ee1c126707ab54a8b72815c08b49/triton-2.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a2294514340cfe4e8f4f9e5c66c702744c4a117d25e618bd08469d0bfed1e2e5", size = 167900779, upload-time = "2024-01-10T03:11:56.576Z" },


### PR DESCRIPTION
## Summary

Major changes:

- fix 1: add `required-environments` to enable install on linux

previously, I got this on error on main with `uv 0.8.12` on a linux machine

```
$ uv sync
Resolved 335 packages in 4.80s
warning: `configargparse==1.7` is yanked (reason: "incorrect metadata related to supported python versions")
error: Distribution `dgl==2.2.0 @ registry+https://pypi.org/simple` can't be installed because it doesn't have a source distribution or wheel for the current platform

hint: You're on Linux (`manylinux_2_39_x86_64`), but `dgl` (v2.2.0) only has wheels for the following platforms: `macosx_11_0_arm64`, `macosx_11_0_x86_64`; consider adding your platform to `tool.uv.required-environments` to ensure uv resolves to a version with compatible wheels
``` 

- [ ] Google format doc strings added. Check with `ruff`.
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
