### PR TITLE
Indicate units and source location of materials properties calculated by MatCalc

### DIFF
--- a/src/matcalc/_elasticity.py
+++ b/src/matcalc/_elasticity.py
@@ -120,12 +120,21 @@ class ElasticityCalc(PropCalc):
             A dictionary containing the calculation results that include:
             - `elastic_tensor`: The computed elastic tensor of the material.
             - `shear_modulus_vrh`: Shear modulus obtained from the elastic tensor
-              using the Voigt-Reuss-Hill approximation.
+              using the Voigt-Reuss-Hill approximation in eV/A3.
             - `bulk_modulus_vrh`: Bulk modulus calculated using the Voigt-Reuss-Hill
-              approximation.
-            - `youngs_modulus`: Young's modulus derived from the elastic tensor.
+              approximation in eV/A3.
+            - `youngs_modulus`: Young's modulus derived from the elastic tensor in SI unit.
             - `residuals_sum`: The residual sum from the elastic tensor fitting.
             - `structure`: The (potentially relaxed) final structure after calculations.
+            The units are originally documented in pymatgen.
+            See pymatgen.analysis.elasticity.elastic.ElasticTensor()
+            (https://github.com/materialsproject/pymatgen/blob/master/src/pymatgen/analysis/elasticity/elastic.py/#130)
+            -> pymatgen.analysis.elasticity.elastic.ElasticTensor.k_vrh()
+            (https://github.com/materialsproject/pymatgen/blob/master/src/pymatgen/analysis/elasticity/elastic.py/#189)
+            pymatgen.analysis.elasticity.elastic.ElasticTensor.g_vrh()
+            (https://github.com/materialsproject/pymatgen/blob/master/src/pymatgen/analysis/elasticity/elastic.py/#194)
+            pymatgen.analysis.elasticity.elastic.ElasticTensor.y_mod()
+            (https://github.com/materialsproject/pymatgen/blob/master/src/pymatgen/analysis/elasticity/elastic.py/#199)
         """
         result = super().calc(structure)
         structure_in: Structure | Atoms = result["final_structure"]

--- a/src/matcalc/_eos.py
+++ b/src/matcalc/_eos.py
@@ -119,6 +119,13 @@ class EOSCalc(PropCalc):
             structures under conditions of strain, energy-volume data, Birch-Murnaghan
             bulk modulus (in GPa), and R-squared fit of the Birch-Murnaghan model to the
             data.
+        The units are originally documented in pymatgen.
+        See pymatgen.analysis.eos.BirchMurnaghan()
+        (https://github.com/materialsproject/pymatgen/blob/master/src/pymatgen/analysis/eos.py/#316)
+        -> pymatgen.analysis.eos.EOSBase()
+        (https://github.com/materialsproject/pymatgen/blob/master/src/pymatgen/analysis/eos.py/#38)
+        -> pymatgen.analysis.eos.EOSBase.b0_GPa()
+        (https://github.com/materialsproject/pymatgen/blob/master/src/pymatgen/analysis/eos.py/#155)
         """
         result = super().calc(structure)
         structure_in: Structure = to_pmg_structure(result["final_structure"])

--- a/src/matcalc/_phonon3.py
+++ b/src/matcalc/_phonon3.py
@@ -162,8 +162,15 @@ class Phonon3Calc(PropCalc):
             - "temperatures": A numpy array of temperatures over which thermal
               conductivity has been computed.
             - "thermal_conductivity": The averaged thermal conductivity values computed
-              at the specified temperatures. Returns NaN if the values cannot be
+              at the specified temperatures in W/m-K. Returns NaN if the values cannot be
               computed.
+              The units are originally documented in phono3py.
+              See phono3py.Phono3py.thermal_conductivity()
+              (https://github.com/phonopy/phono3py/blob/master/phono3py/api_phono3py.py/#877)
+              -> phono3py.conductivity.init_rta.get_thermal_conductivity_RTA()
+              (https://github.com/phonopy/phono3py/blob/master/phono3py/conductivity/init_rta.py/#58)
+              -> phono3py.conductivity.init_rta.ShowCalcProgress.kappa_Wigner_RTA()
+              (https://github.com/phonopy/phono3py/blob/master/phono3py/conductivity/init_rta.py/#217)
         """
         result = super().calc(structure)
         structure_in: Structure = result["final_structure"]


### PR DESCRIPTION
## Summary

This PR introduces documentation for units of materials properties calculated by MatCalc, and indicates their locations (file, function and line) in the original package, as what I did in the PhononCalc. This aims to make it easier for users and developers to understand the units associated with each property and trace back to the upstream package.

Major changes:

- feature 1: Added docstrings to units of key materials properties (bulk modulus, shear modulus, Young's modulus, thermal conductivity, etc.).
- feature 2: Indicated the original source file and line number in the upstream package for each documented unit.

## Todos

If this is work in progress, what else needs to be done?

- feature 2: ...
- fix 2:

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
