### PR TITLE
Fix: Clarify np.transpose usage in QHA calculation (Issue #130)

### DIFF
--- a/src/matcalc/_qha.py
+++ b/src/matcalc/_qha.py
@@ -345,9 +345,11 @@ class QHACalc(PropCalc):
             volumes=volumes,
             electronic_energies=electronic_energies,
             temperatures=temperatures,
-            free_energy=np.transpose(free_energies),
-            cv=np.transpose(heat_capacities),
-            entropy=np.transpose(entropies),
+            # Transpose thermal properties to convert from (volumes x temperatures) to
+            # (temperatures x volumes) format expected by PhonopyQHA
+            free_energy=np.transpose(np.asarray(free_energies)),
+            cv=np.transpose(np.asarray(heat_capacities)),
+            entropy=np.transpose(np.asarray(entropies)),
             pressure=pressure,
             eos=self.eos,
             t_max=self.t_max,


### PR DESCRIPTION
## Summary

This PR addresses issue #130 which raised a concern about the unclear usage of `np.transpose()` on list types in the QHA calculation.

## Changes

- Convert lists to numpy arrays using `np.asarray()` before transposing
- Add explanatory comment clarifying why we transpose the thermal properties
- The transpose converts data from (volumes × temperatures) to (temperatures × volumes) format as expected by PhonopyQHA

## Rationale

The issue reporter was confused because the docstrings state that `free_energies`, `entropies`, and `heat_capacities` are lists, making the `np.transpose()` call appear incorrect. 

However, the transpose operation is actually correct. The data is structured as a list where each element is an array of thermal properties at different temperatures for a specific volume. PhonopyQHA expects the transposed format where each element is an array of thermal properties at different volumes for a specific temperature.

By explicitly converting to numpy arrays and adding a clear comment, we make the code more understandable and prevent future confusion.

## Testing

The existing tests in `tests/test_qha.py` continue to pass with this change, confirming that the transpose operation is correct.