### PR TITLE
Relax the positions in QHA workflow

### DIFF
--- a/src/matcalc/_qha.py
+++ b/src/matcalc/_qha.py
@@ -299,7 +299,8 @@ class QHACalc(PropCalc):
             t_step=self.t_step,
             t_max=self.t_max,
             t_min=self.t_min,
-            relax_structure=False,
+            relax_structure=True,
+            relax_calc_kwargs={"relax_cell": False},
             write_phonon=False,
             **(self.phonon_calc_kwargs or {}),
         )


### PR DESCRIPTION
To the best of my understanding, the `QHACalc` is not currently relaxing the atomic positions (at fixed cell volume) for each scaled structure, which would be a problem. I have fixed that. Closes #157.