### PR TITLE
Remove one-line helper functions in `QHACalc`

### DIFF
--- a/src/matcalc/_qha.py
+++ b/src/matcalc/_qha.py
@@ -254,17 +254,15 @@ class QHACalc(PropCalc):
             structure_in = result["final_structure"]
 
         temperatures = np.arange(self.t_min, self.t_max + self.t_step, self.t_step)
-        volumes, electronic_energies, free_energies, entropies, heat_capacities, scaled_structures = (
-            self._collect_properties(structure_in)
-        )
+        properties = self._collect_properties(structure_in)
 
         qha = PhonopyQHA(
-            volumes=volumes,
-            electronic_energies=electronic_energies,
+            volumes=properties["volumes"],
+            electronic_energies=properties["electronic_energies"],
             temperatures=temperatures,
-            free_energy=np.transpose(free_energies),
-            cv=np.transpose(heat_capacities),
-            entropy=np.transpose(entropies),
+            free_energy=np.transpose(properties["free_energies"]),
+            cv=np.transpose(properties["heat_capacities"]),
+            entropy=np.transpose(properties["entropies"]),
             pressure=self.pressure,
             eos=self.eos,
             t_max=self.t_max,
@@ -274,9 +272,9 @@ class QHACalc(PropCalc):
         output_dict = {
             "qha": qha,
             "scale_factors": self.scale_factors,
-            "volumes": volumes,
-            "scaled_structures": scaled_structures,
-            "electronic_energies": electronic_energies,
+            "volumes": properties["volumes"],
+            "scaled_structures": properties["scaled_structures"],
+            "electronic_energies": properties["electronic_energies"],
             "temperatures": temperatures,
             "thermal_expansion_coefficients": qha.thermal_expansion,
             "gibbs_free_energies": qha.gibbs_temperature,
@@ -287,7 +285,7 @@ class QHACalc(PropCalc):
 
         return result | output_dict
 
-    def _collect_properties(self, structure: Structure) -> tuple[list, list, list, list, list, list]:
+    def _collect_properties(self, structure: Structure) -> dict[str, list]:
         """Helper to collect properties like volumes, electronic energies, and thermal properties.
 
         Args:
@@ -324,7 +322,14 @@ class QHACalc(PropCalc):
             free_energies.append(thermal_properties["free_energy"])
             entropies.append(thermal_properties["entropy"])
             heat_capacities.append(thermal_properties["heat_capacity"])
-        return volumes, electronic_energies, free_energies, entropies, heat_capacities, scaled_structures
+        return {
+            "volumes": volumes,
+            "electronic_energies": electronic_energies,
+            "free_energies": free_energies,
+            "entropies": entropies,
+            "heat_capacities": heat_capacities,
+            "scaled_structures": scaled_structures,
+        }
 
     def _scale_structure(self, structure: Structure, scale_factor: float) -> Structure:
         """Helper to scale the lattice of a structure.


### PR DESCRIPTION
## Summary
There were some single-use, one-line "helper functions" in `QHACalc` that did not abstract away any code and instead just made the module more verbose than necessary. I have removed these single-use, one-line helper functions.

Additionally, `_collect_properties()` returned a long `tuple[list]` that could be prone to errors if a developer indexes the wrong entry in the tuple. I have made this internal function return a `dict[str, list]` instead for greater clarity.

## Checklist

- [X] Google format doc strings added. Check with `ruff`.
- [X] Type annotations included. Check with `mypy`.
- [X] Tests added for new features/fixes.
- [X] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
