### PR TITLE
Add a `tqdm` progress bar to `QHACalc`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,8 @@ dependencies = [
     "joblib>=1.4.2",
     "phonopy>=2.38.0",
     "phono3py>=3.15.0",
-    "nvalchemi-toolkit-ops"
+    "nvalchemi-toolkit-ops",
+    "tqdm>=4.67.3",
 ]
 version = "0.4.5"
 

--- a/src/matcalc/_qha.py
+++ b/src/matcalc/_qha.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from phonopy import PhonopyQHA
+from tqdm import tqdm
 
 from ._base import PropCalc
 from ._phonon import PhononCalc
@@ -301,7 +302,7 @@ class QHACalc(PropCalc):
         entropies = []
         heat_capacities = []
         scaled_structures = []
-        for scale_factor in self.scale_factors:
+        for scale_factor in tqdm(self.scale_factors, desc="Performing analysis on scale factors"):
             # Apply linear strain
             struct = self._scale_structure(structure, scale_factor)
             volumes.append(struct.volume)


### PR DESCRIPTION
## Summary

It is typically the case that `QHACalc` runs are very long, but there is no way to monitor the progress currently. Since pymagen is a core dependency, and pymatgen requires tqdm, I have added a `tqdm` progress bar to the `QHACalc` so that each scale factor can be tracked.

## Checklist

- [X] Google format doc strings added. Check with `ruff`.
- [X] Type annotations included. Check with `mypy`.
- [X] Tests added for new features/fixes.
- [X] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
