### PR TITLE
Allow users to switch between relaxations at constant volume w/ shape or w/o shape relaxations for EOS

### DIFF
--- a/src/matcalc/_eos.py
+++ b/src/matcalc/_eos.py
@@ -137,29 +137,24 @@ class EOSCalc(PropCalc):
         """
         result = super().calc(structure)
         structure_in: Structure = to_pmg_structure(result["final_structure"])
+        relax_calc_kwargs = {
+            "optimizer": self.optimizer,
+            "fmax": self.fmax,
+            "max_steps": self.max_steps,
+            **(self.relax_calc_kwargs or {}),
+        }
 
         if self.relax_structure:
-            relaxer = RelaxCalc(
-                self.calculator,
-                optimizer=self.optimizer,
-                fmax=self.fmax,
-                max_steps=self.max_steps,
-                **(self.relax_calc_kwargs or {}),
-            )
+            relaxer = RelaxCalc(self.calculator, **relax_calc_kwargs)
             result |= relaxer.calc(structure_in)
             structure_in = result["final_structure"]
 
         volumes, energies = [], []
-        relaxer = RelaxCalc(
-            self.calculator,
-            optimizer=self.optimizer,
-            fmax=self.fmax,
-            max_steps=self.max_steps,
-            **(self.relax_calc_kwargs or {}),
-            # These must come at the end to prevent them from being changed
-            relax_cell=bool(self.allow_shape_change),
-            cell_filter_kwargs={"constant_volume": True} if self.allow_shape_change else {},
-        )
+
+        # Don't relax the volume!
+        relax_calc_kwargs["relax_cell"] = bool(self.allow_shape_change)
+        relax_calc_kwargs["cell_filter_kwargs"] = {"constant_volume": True} if self.allow_shape_change else {}
+        relaxer = RelaxCalc(self.calculator, **relax_calc_kwargs)
 
         temp_structure = structure_in.copy()
         for idx in np.linspace(-self.max_abs_strain, self.max_abs_strain, self.n_points)[self.n_points // 2 :]:


### PR DESCRIPTION
## Summary

Strictly speaking, EOS should generally be generated from constant volume relaxations that allow the cell shape to change. Ultimately, this should become the default, and we should provide the user with the option to change it. 

I have added a keyword argument `allow_shape_change: bool = True` to `EOSCalc`.
## ToDo

- Add a test
- Make sure the appropriate optimizers are used

## Checklist

- [X] Google format doc strings added. Check with `ruff`.
- [X] Type annotations included. Check with `mypy`.
- [X] Tests added for new features/fixes.
- [X] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
