### PR TITLE
Add support for multiple pressures in `QHACalc`

### DIFF
--- a/src/matcalc/_qha.py
+++ b/src/matcalc/_qha.py
@@ -261,16 +261,18 @@ class QHACalc(PropCalc):
                 eos=self.eos,
             )
             self._write_output_files(qha, pressure=pressure)
-            qha_results.append({
-                "pressure": pressure,
-                "qha": qha,
-                "temperatures": temperatures,
-                "thermal_expansion_coefficients": qha.thermal_expansion,
-                "gibbs_free_energies": qha.gibbs_temperature,
-                "bulk_modulus_P": qha.bulk_modulus_temperature,
-                "heat_capacity_P": qha.heat_capacity_P_polyfit,
-                "gruneisen_parameters": qha.gruneisen_temperature,
-            })
+            qha_results.append(
+                {
+                    "pressure": pressure,
+                    "qha": qha,
+                    "temperatures": temperatures,
+                    "thermal_expansion_coefficients": qha.thermal_expansion,
+                    "gibbs_free_energies": qha.gibbs_temperature,
+                    "bulk_modulus_P": qha.bulk_modulus_temperature,
+                    "heat_capacity_P": qha.heat_capacity_P_polyfit,
+                    "gruneisen_parameters": qha.gruneisen_temperature,
+                }
+            )
 
         output_dict: dict[str, Any] = {
             "pressures": self.pressures,

--- a/src/matcalc/_qha.py
+++ b/src/matcalc/_qha.py
@@ -134,7 +134,6 @@ class QHACalc(PropCalc):
         self.fix_imaginary_attempts = fix_imaginary_attempts
 
         # Normalize pressure to an internal list; None becomes [None].
-        # self.pressure preserves the original input for repr/serialization.
         self.pressure = pressure
         if pressure is None:
             self.pressures: list[float | None] = [None]
@@ -188,9 +187,6 @@ class QHACalc(PropCalc):
 
     def calc(self, structure: Structure | Atoms | dict[str, Any]) -> dict:
         """Quasi-harmonic thermodynamics via phonopy over a volume scan.
-
-        The expensive phonon calculations are performed once across all scale factors.
-        The QHA fit is then repeated cheaply for each pressure in ``self.pressures``.
 
         Args:
             structure: Pymatgen structure, ASE atoms, or dict with structure keys.

--- a/src/matcalc/_qha.py
+++ b/src/matcalc/_qha.py
@@ -261,22 +261,20 @@ class QHACalc(PropCalc):
                 eos=self.eos,
             )
             self._write_output_files(qha, pressure=pressure)
-            qha_results.append(
-                {
-                    "pressure": pressure,
-                    "qha": qha,
-                    "temperatures": temperatures,
-                    "thermal_expansion_coefficients": qha.thermal_expansion,
-                    "gibbs_free_energies": qha.gibbs_temperature,
-                    "bulk_modulus_P": qha.bulk_modulus_temperature,
-                    "heat_capacity_P": qha.heat_capacity_P_polyfit,
-                    "gruneisen_parameters": qha.gruneisen_temperature,
-                }
-            )
+            qha_results.append({
+                "pressure": pressure,
+                "qha": qha,
+                "temperatures": temperatures,
+                "thermal_expansion_coefficients": qha.thermal_expansion,
+                "gibbs_free_energies": qha.gibbs_temperature,
+                "bulk_modulus_P": qha.bulk_modulus_temperature,
+                "heat_capacity_P": qha.heat_capacity_P_polyfit,
+                "gruneisen_parameters": qha.gruneisen_temperature,
+            })
 
-            if self.store_ha_phonon:
-                qha_results["ha"] = properties["ha"]
-
+        if self.store_ha_phonon:
+            output_dict["ha"] = properties["ha"]
+            
         output_dict: dict[str, Any] = {
             "pressures": self.pressures,
             "scale_factors": self.scale_factors,
@@ -289,6 +287,7 @@ class QHACalc(PropCalc):
         # Backward-compatible unwrap for the single-pressure case.
         if len(self.pressures) == 1:
             output_dict |= qha_results[0]
+
 
         return result | output_dict
 

--- a/src/matcalc/_qha.py
+++ b/src/matcalc/_qha.py
@@ -389,7 +389,7 @@ class QHACalc(PropCalc):
             if pressure is None or len(self.pressures) == 1:
                 return path
             s = str(path)
-            stem, dot, ext = s.rpartition(".")
+            stem, _, ext = s.rpartition(".")
             return f"{stem}_P{pressure}GPa.{ext}" if stem else f"{s}_P{pressure}GPa"
 
         # write_* are Optional[str | os.PathLike]; None means "do not write".

--- a/src/matcalc/_qha.py
+++ b/src/matcalc/_qha.py
@@ -261,20 +261,22 @@ class QHACalc(PropCalc):
                 eos=self.eos,
             )
             self._write_output_files(qha, pressure=pressure)
-            qha_results.append({
-                "pressure": pressure,
-                "qha": qha,
-                "temperatures": temperatures,
-                "thermal_expansion_coefficients": qha.thermal_expansion,
-                "gibbs_free_energies": qha.gibbs_temperature,
-                "bulk_modulus_P": qha.bulk_modulus_temperature,
-                "heat_capacity_P": qha.heat_capacity_P_polyfit,
-                "gruneisen_parameters": qha.gruneisen_temperature,
-            })
+            qha_results.append(
+                {
+                    "pressure": pressure,
+                    "qha": qha,
+                    "temperatures": temperatures,
+                    "thermal_expansion_coefficients": qha.thermal_expansion,
+                    "gibbs_free_energies": qha.gibbs_temperature,
+                    "bulk_modulus_P": qha.bulk_modulus_temperature,
+                    "heat_capacity_P": qha.heat_capacity_P_polyfit,
+                    "gruneisen_parameters": qha.gruneisen_temperature,
+                }
+            )
 
         if self.store_ha_phonon:
             output_dict["ha"] = properties["ha"]
-            
+
         output_dict: dict[str, Any] = {
             "pressures": self.pressures,
             "scale_factors": self.scale_factors,
@@ -287,7 +289,6 @@ class QHACalc(PropCalc):
         # Backward-compatible unwrap for the single-pressure case.
         if len(self.pressures) == 1:
             output_dict |= qha_results[0]
-
 
         return result | output_dict
 

--- a/src/matcalc/_qha.py
+++ b/src/matcalc/_qha.py
@@ -246,7 +246,6 @@ class QHACalc(PropCalc):
                 {
                     "pressure": pressure,
                     "qha": qha,
-                    "temperatures": temperatures,
                     "thermal_expansion_coefficients": qha.thermal_expansion,
                     "gibbs_free_energies": qha.gibbs_temperature,
                     "bulk_modulus_P": qha.bulk_modulus_temperature,
@@ -257,6 +256,7 @@ class QHACalc(PropCalc):
 
         output_dict: dict[str, Any] = {
             "pressures": self.pressures,
+            "temperatures": temperatures,
             "qha_results": qha_results,
             "scale_factors": self.scale_factors,
             "volumes": properties["volumes"],

--- a/src/matcalc/_qha.py
+++ b/src/matcalc/_qha.py
@@ -373,7 +373,7 @@ class QHACalc(PropCalc):
         )
         return phonon_calc.calc(structure)
 
-    def _write_output_files(self, qha: PhonopyQHA, pressure: float | None = None) -> None:
+    def _write_output_files(self, qha: PhonopyQHA, pressure: float | None = None) -> None:  # noqa: C901
         """Helper to write various output files based on the QHA calculation.
 
         When multiple pressures are requested, a ``_P{pressure}GPa`` suffix is inserted

--- a/src/matcalc/_qha.py
+++ b/src/matcalc/_qha.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-import logging
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING
 
 import numpy as np
 from phonopy import PhonopyQHA
@@ -11,18 +10,16 @@ from phonopy import PhonopyQHA
 from ._base import PropCalc
 from ._phonon import PhononCalc
 from ._relaxation import RelaxCalc
-from .utils import to_pmg_structure
+from .backend import run_pes_calc
 
 if TYPE_CHECKING:
-    import os
     from collections.abc import Sequence
-    from typing import Literal
+    from pathlib import Path
+    from typing import Any, Literal
 
     from ase import Atoms
     from ase.calculators.calculator import Calculator
     from pymatgen.core import Structure
-
-logger = logging.getLogger(__name__)
 
 
 class QHACalc(PropCalc):
@@ -36,30 +33,50 @@ class QHACalc(PropCalc):
     and fine-tuning various calculation parameters. Calculation results can be selectively
     saved to output files.
 
-    Attributes:
-        calculator: ASE calculator or universal model name.
-        t_step, t_max, t_min: Temperature grid (K) for QHA output.
-        pressure: Target pressure(s) in GPa. Accepts a single float, a list of floats, or
-            None. When multiple pressures are given the expensive phonon calculations are
-            run once and the cheap QHA fitting is repeated per pressure.
-        fmax: Relaxation force tolerance (eV/Å).
-        max_steps: Max relaxation steps.
-        optimizer: ASE optimizer name.
-        eos: EOS model for volume-energy fits (``vinet``, ``birch_murnaghan``, ``murnaghan``).
-        allow_shape_change: Allow cell shape change at fixed volume in scaled relaxations.
-        relax_structure: Relax initial structure before the QHA volume scan.
-        relax_calc_kwargs: Kwargs merged into all ``RelaxCalc`` uses.
-        phonon_calc_kwargs: Kwargs merged into ``PhononCalc``.
-        scale_factors: Volume scale factors for the QHA mesh.
-        imaginary_freq_tol, on_imaginary_modes, fix_imaginary_attempts: Passed to ``PhononCalc``.
-        store_ha_phonon: Whether to store per-scale-factor harmonic approximation results in
-            the output dict under the ``"ha"`` key.
-        write_ha_phonon: Write per-scale-factor phonopy files. False disables writing,
-            True uses the default name ``phonon_{scale_factor:.3f}.yaml``, or a format string
-            with a ``{scale_factor}`` placeholder selects a custom name.
-        write_*: Output paths (or True for defaults) for phonopy QHA text files. When
-            multiple pressures are requested a ``_P{pressure}GPa`` suffix is inserted before
-            the file extension to avoid overwriting files across pressures.
+    :ivar calculator: Calculator instance used for electronic structure or energy calculations.
+    :type calculator: Calculator
+    :ivar t_step: Temperature step size in Kelvin.
+    :type t_step: float
+    :ivar t_max: Maximum temperature in Kelvin.
+    :type t_max: float
+    :ivar t_min: Minimum temperature in Kelvin.
+    :type t_min: float
+    :ivar pressure: Target pressure(s) in GPa. Accepts a single float, a list of floats, or
+        None. When multiple pressures are given the expensive phonon calculations are run once
+        and the cheap QHA fitting is repeated per pressure.
+    :type pressure: float | list[float] | None
+    :ivar fmax: Maximum force threshold for structure relaxation in eV/Å.
+    :type fmax: float
+    :ivar optimizer: Type of optimizer used for structural relaxation.
+    :type optimizer: str
+    :ivar eos: Equation of state used for fitting energy vs. volume data.
+    :type eos: Literal["vinet", "birch_murnaghan", "murnaghan"]
+    :ivar relax_structure: Whether to perform structure relaxation before phonon calculations.
+    :type relax_structure: bool
+    :ivar relax_calc_kwargs: Additional keyword arguments for structure relaxation calculations.
+    :type relax_calc_kwargs: dict | None
+    :ivar phonon_calc_kwargs: Additional keyword arguments for phonon calculations.
+    :type phonon_calc_kwargs: dict | None
+    :ivar scale_factors: List of scale factors for lattice scaling.
+    :type scale_factors: Sequence[float]
+    :ivar write_helmholtz_volume: Path or boolean to control saving Helmholtz free energy vs. volume data.
+    :type write_helmholtz_volume: bool | str | Path
+    :ivar write_volume_temperature: Path or boolean to control saving volume vs. temperature data.
+    :type write_volume_temperature: bool | str | Path
+    :ivar write_thermal_expansion: Path or boolean to control saving thermal expansion coefficient data.
+    :type write_thermal_expansion: bool | str | Path
+    :ivar write_gibbs_temperature: Path or boolean to control saving Gibbs free energy as a function of temperature.
+    :type write_gibbs_temperature: bool | str | Path
+    :ivar write_bulk_modulus_temperature: Path or boolean to control saving bulk modulus vs. temperature data.
+    :type write_bulk_modulus_temperature: bool | str | Path
+    :ivar write_heat_capacity_p_numerical: Path or boolean to control saving numerically calculated heat capacity vs.
+        temperature data.
+    :type write_heat_capacity_p_numerical: bool | str | Path
+    :ivar write_heat_capacity_p_polyfit: Path or boolean to control saving polynomial-fitted heat capacity vs.
+        temperature data.
+    :type write_heat_capacity_p_polyfit: bool | str | Path
+    :ivar write_gruneisen_temperature: Path or boolean to control saving Grüneisen parameter vs. temperature data.
+    :type write_gruneisen_temperature: bool | str | Path
     """
 
     def __init__(
@@ -69,86 +86,82 @@ class QHACalc(PropCalc):
         t_step: float = 10,
         t_max: float = 1000,
         t_min: float = 0,
+        fmax: float = 0.05,
         pressure: None | float | Sequence[float] = None,
-        fmax: float = 1e-5,
-        max_steps: int = 5000,
         optimizer: str = "FIRE",
         eos: Literal["vinet", "birch_murnaghan", "murnaghan"] = "vinet",
-        allow_shape_change: bool = True,
         relax_structure: bool = True,
         relax_calc_kwargs: dict | None = None,
         phonon_calc_kwargs: dict | None = None,
-        scale_factors: Sequence[float] = (0.95, 0.96, 0.97, 0.98, 0.99, 1.0, 1.01, 1.02, 1.03, 1.04, 1.05),
-        imaginary_freq_tol: float = -0.01,
-        on_imaginary_modes: Literal["error", "warn"] = "warn",
-        fix_imaginary_attempts: int = 0,
-        store_ha_phonon: bool = True,
-        write_ha_phonon: bool | str = False,
-        write_helmholtz_volume: bool | str | os.PathLike = False,
-        write_volume_temperature: bool | str | os.PathLike = False,
-        write_thermal_expansion: bool | str | os.PathLike = False,
-        write_gibbs_temperature: bool | str | os.PathLike = False,
-        write_bulk_modulus_temperature: bool | str | os.PathLike = False,
-        write_heat_capacity_p_numerical: bool | str | os.PathLike = False,
-        write_heat_capacity_p_polyfit: bool | str | os.PathLike = False,
-        write_gruneisen_temperature: bool | str | os.PathLike = False,
+        scale_factors: Sequence[float] = tuple(np.arange(0.95, 1.05, 0.01)),
+        write_helmholtz_volume: bool | str | Path = False,
+        write_volume_temperature: bool | str | Path = False,
+        write_thermal_expansion: bool | str | Path = False,
+        write_gibbs_temperature: bool | str | Path = False,
+        write_bulk_modulus_temperature: bool | str | Path = False,
+        write_heat_capacity_p_numerical: bool | str | Path = False,
+        write_heat_capacity_p_polyfit: bool | str | Path = False,
+        write_gruneisen_temperature: bool | str | Path = False,
     ) -> None:
         """
-        Args:
-            calculator: ASE calculator or universal model name string.
-            t_step: Temperature sampling step (K).
-            t_max: Maximum temperature (K).
-            t_min: Minimum temperature (K).
-            pressure: Pressure in GPa for Gibbs terms. Accepts a single float, a list of
-                floats, or None. When multiple pressures are supplied the phonon calculations
-                are performed only once and the QHA fit is repeated for each pressure.
-            fmax: Force tolerance for relaxations.
-            max_steps: Max steps per relaxation.
-            optimizer: ASE optimizer name.
-            eos: EOS key for ``PhonopyQHA``.
-            allow_shape_change: Allow shape relaxation at constant volume for scaled cells.
-            relax_structure: Relax input once before scanning ``scale_factors``.
-            relax_calc_kwargs: Extra kwargs for every ``RelaxCalc``.
-            phonon_calc_kwargs: Extra kwargs for each ``PhononCalc``.
-            scale_factors: Volume scale factors applied to the relaxed structure.
-            imaginary_freq_tol: Imaginary-mode threshold (THz) for ``PhononCalc``.
-            on_imaginary_modes: ``"warn"`` or ``"error"``.
-            fix_imaginary_attempts: Imaginary-mode retries per scale factor in ``PhononCalc``.
-            store_ha_phonon: If True (default), each per-scale-factor ``PhononCalc`` result
-                dict is stored and returned under the ``"ha"`` key. Set to False to skip
-                storing these results and omit the ``"ha"`` key from the output entirely.
-            write_ha_phonon: Write a phonopy file for each scale factor. False (default)
-                disables writing. True writes ``phonon_{scale_factor:.3f}.yaml``. A format
-                string containing ``{scale_factor}`` selects a custom filename pattern.
-            write_helmholtz_volume: Write F(V); True selects default filename.
-            write_volume_temperature: Write V(T).
-            write_thermal_expansion: Write thermal expansion alpha(T).
-            write_gibbs_temperature: Write G(T).
-            write_bulk_modulus_temperature: Write B(T).
-            write_heat_capacity_p_numerical: Write Cp(T) numerical.
-            write_heat_capacity_p_polyfit: Write Cp(T) polyfit.
-            write_gruneisen_temperature: Write Gruneisen gamma(T).
+        Initializes the class that handles thermal and structural calculations, including atomic
+        structure relaxation, property evaluations, and phononic calculations across temperature
+        ranges. This class is mainly designed to facilitate systematic computations involving
+        temperature-dependent material properties and thermodynamic quantities.
+
+        :param calculator: Calculator object or string indicating the computational engine to use
+            for performing calculations.
+        :param t_step: Step size for the temperature range, given in units of K.
+        :param t_max: Maximum temperature for the calculations, given in units of K.
+        :param t_min: Minimum temperature for the calculations, given in units of K.
+        :param pressure: Pressure in GPa for Gibbs terms. Accepts a single float, a list of
+            floats, or None. When multiple pressures are supplied the phonon calculations are
+            performed only once and the QHA fit is repeated for each pressure.
+        :param fmax: Maximum force convergence criterion for structure relaxation, in force units.
+        :param optimizer: Name of the optimizer to use for structure optimization, default is
+            "FIRE".
+        :param eos: Equation of state to use for calculating energy vs. volume relationships.
+            Default is "vinet".
+        :param relax_structure: A boolean flag indicating whether the atomic structure should be
+            relaxed as part of the computation workflow.
+        :param relax_calc_kwargs: A dictionary containing additional keyword arguments to pass to
+            the relax calculation.
+        :param phonon_calc_kwargs: A dictionary containing additional parameters to pass to the
+            phonon calculation routine.
+        :param scale_factors: A sequence of scale factors for volume scaling during
+            thermodynamic and phononic calculations.
+        :param write_helmholtz_volume: Path, boolean, or string to indicate whether and where
+            to save Helmholtz energy as a function of volume.
+        :param write_volume_temperature: Path, boolean, or string to indicate whether and where
+            to save equilibrium volume as a function of temperature.
+        :param write_thermal_expansion: Path, boolean, or string to indicate whether and where
+            to save the thermal expansion coefficient as a function of temperature.
+        :param write_gibbs_temperature: Path, boolean, or string to indicate whether and where
+            to save Gibbs energy as a function of temperature.
+        :param write_bulk_modulus_temperature: Path, boolean, or string to indicate whether and
+            where to save bulk modulus as a function of temperature.
+        :param write_heat_capacity_p_numerical: Path, boolean, or string to indicate whether and
+            where to save specific heat capacity at constant pressure, calculated numerically.
+        :param write_heat_capacity_p_polyfit: Path, boolean, or string to indicate whether and
+            where to save specific heat capacity at constant pressure, calculated via polynomial
+            fitting.
+        :param write_gruneisen_temperature: Path, boolean, or string to indicate whether and
+            where to save Grüneisen parameter values as a function of temperature.
         """
         self.calculator = calculator  # type: ignore[assignment]
         self.t_step = t_step
         self.t_max = t_max
         self.t_min = t_min
         self.fmax = fmax
-        self.max_steps = max_steps
         self.optimizer = optimizer
         self.eos = eos
-        self.allow_shape_change = allow_shape_change
         self.relax_structure = relax_structure
         self.relax_calc_kwargs = relax_calc_kwargs
         self.phonon_calc_kwargs = phonon_calc_kwargs
         self.scale_factors = scale_factors
-        self.imaginary_freq_tol = imaginary_freq_tol
-        self.on_imaginary_modes = on_imaginary_modes
-        self.fix_imaginary_attempts = fix_imaginary_attempts
-        self.store_ha_phonon = store_ha_phonon
-        self.write_ha_phonon = write_ha_phonon
 
         # Normalize pressure to an internal list; None becomes [None].
+        # self.pressure preserves the original input for repr/serialization.
         self.pressure = pressure
         if pressure is None:
             self.pressures: list[float | None] = [None]
@@ -157,130 +170,89 @@ class QHACalc(PropCalc):
         else:
             self.pressures = list(pressure)
 
-        # Needed to make sure the volume doesn't change during relaxations on scaled structures
-        self._fixed_cell_relax_calc_kwargs = {
-            "optimizer": self.optimizer,
-            "fmax": self.fmax,
-            "max_steps": self.max_steps,
-            **(self.relax_calc_kwargs or {}),
-        }
-        self._fixed_cell_relax_calc_kwargs["relax_cell"] = bool(self.allow_shape_change)
-        self._fixed_cell_relax_calc_kwargs["cell_filter_kwargs"] = (
-            {"constant_volume": True} if self.allow_shape_change else {}
-        )
-
-        # Normalize write_* inputs to Optional[str | os.PathLike]:
-        # - True  -> default filename (meaning "write to default file")
-        # - False -> None (disabled)
-        # - str/PathLike -> keep as-is (user-provided path)
-        self.write_helmholtz_volume: str | os.PathLike | None = None
-        self.write_volume_temperature: str | os.PathLike | None = None
-        self.write_thermal_expansion: str | os.PathLike | None = None
-        self.write_gibbs_temperature: str | os.PathLike | None = None
-        self.write_bulk_modulus_temperature: str | os.PathLike | None = None
-        self.write_heat_capacity_p_numerical: str | os.PathLike | None = None
-        self.write_heat_capacity_p_polyfit: str | os.PathLike | None = None
-        self.write_gruneisen_temperature: str | os.PathLike | None = None
-
+        self.write_helmholtz_volume = write_helmholtz_volume
+        self.write_volume_temperature = write_volume_temperature
+        self.write_thermal_expansion = write_thermal_expansion
+        self.write_gibbs_temperature = write_gibbs_temperature
+        self.write_bulk_modulus_temperature = write_bulk_modulus_temperature
+        self.write_heat_capacity_p_numerical = write_heat_capacity_p_numerical
+        self.write_heat_capacity_p_polyfit = write_heat_capacity_p_polyfit
+        self.write_gruneisen_temperature = write_gruneisen_temperature
         for key, val, default_path in (
-            ("write_helmholtz_volume", write_helmholtz_volume, "helmholtz_volume.dat"),
-            ("write_volume_temperature", write_volume_temperature, "volume_temperature.dat"),
-            ("write_thermal_expansion", write_thermal_expansion, "thermal_expansion.dat"),
-            ("write_gibbs_temperature", write_gibbs_temperature, "gibbs_temperature.dat"),
-            ("write_bulk_modulus_temperature", write_bulk_modulus_temperature, "bulk_modulus_temperature.dat"),
-            ("write_heat_capacity_p_numerical", write_heat_capacity_p_numerical, "Cp_temperature.dat"),
-            ("write_heat_capacity_p_polyfit", write_heat_capacity_p_polyfit, "Cp_temperature_polyfit.dat"),
-            ("write_gruneisen_temperature", write_gruneisen_temperature, "gruneisen_temperature.dat"),
+            ("write_helmholtz_volume", self.write_helmholtz_volume, "helmholtz_volume.dat"),
+            ("write_volume_temperature", self.write_volume_temperature, "volume_temperature.dat"),
+            ("write_thermal_expansion", self.write_thermal_expansion, "thermal_expansion.dat"),
+            ("write_gibbs_temperature", self.write_gibbs_temperature, "gibbs_temperature.dat"),
+            ("write_bulk_modulus_temperature", self.write_bulk_modulus_temperature, "bulk_modulus_temperature.dat"),
+            ("write_heat_capacity_p_numerical", self.write_heat_capacity_p_numerical, "Cp_temperature.dat"),
+            ("write_heat_capacity_p_polyfit", self.write_heat_capacity_p_polyfit, "Cp_temperature_polyfit.dat"),
+            ("write_gruneisen_temperature", self.write_gruneisen_temperature, "gruneisen_temperature.dat"),
         ):
-            if val is True:
-                normalized: str | os.PathLike | None = default_path
-            elif val is False:
-                normalized = None
-            else:
-                normalized = val
-            setattr(self, key, normalized)
+            setattr(self, key, str({True: default_path, False: ""}.get(val, val)))  # type: ignore[arg-type]
 
     def calc(self, structure: Structure | Atoms | dict[str, Any]) -> dict:
-        """Quasi-harmonic thermodynamics via phonopy over a volume scan.
+        """Calculates thermal properties of Pymatgen structure with phonopy under quasi-harmonic approximation.
+
+        The expensive phonon calculations are performed once across all scale factors.
+        The QHA fit is then repeated cheaply for each pressure in ``self.pressures``.
 
         Args:
-            structure: Pymatgen structure, ASE atoms, or dict with structure keys.
+            structure: Pymatgen structure.
 
         Returns:
-            Dict with per-volume data (``scale_factors``, ``volumes``, ``electronic_energies``,
-            ``scaled_structures``), a ``temperatures`` array, and a ``qha_results`` dict keyed
-            by pressure (``float | None``) whose values each contain ``qha``,
-            ``thermal_expansion_coefficients``, ``gibbs_free_energies``, ``bulk_modulus_P``,
-            ``heat_capacity_P``, and ``gruneisen_parameters``. When only a single pressure was
-            requested the top-level dict also contains those keys directly for backward
-            compatibility. When ``store_ha_phonon=True``, also includes ``"ha"``: a list of
-            per-scale-factor ``PhononCalc`` result dicts. Merged with any relaxation fields
-            from earlier steps. Units follow phonopy QHA.
+        {
+            "pressures": List of pressures in GPa (or [None]),
+            "qha_results": List of per-pressure dicts, each containing:
+                "pressure": pressure in GPa (or None),
+                "qha": Phonopy.qha object,
+                "temperatures": List of temperatures in ascending order (in Kelvin),
+                "thermal_expansion_coefficients": List of volumetric thermal expansion coefficients (in Kelvin^-1),
+                "gibbs_free_energies": List of Gibbs free energies at corresponding temperatures (in eV),
+                "bulk_modulus_P": List of bulk modulus at constant pressure (in GPa),
+                "heat_capacity_P": List of heat capacities at constant pressure (in J/K/mol),
+                "gruneisen_parameters": List of Gruneisen parameters at corresponding temperatures,
+            "scale_factors": List of scale factors of lattice constants,
+            "volumes": List of unit cell volumes at corresponding scale factors (in Angstrom^3),
+            "electronic_energies": List of electronic energies at corresponding volumes (in eV),
+            # When a single pressure is given the per-pressure keys are also present at the
+            # top level for backward compatibility.
+        }
         """
         result = super().calc(structure)
-        structure_in: Structure = to_pmg_structure(result["final_structure"])
+        structure_in: Structure = result["final_structure"]
 
         if self.relax_structure:
-            logger.info("Relaxing input structure before QHA")
-            result |= RelaxCalc(
+            relaxer = RelaxCalc(
                 self.calculator,
                 fmax=self.fmax,
                 optimizer=self.optimizer,
-                max_steps=self.max_steps,
-                **self.relax_calc_kwargs or {},
-            ).calc(structure_in)
+                **(self.relax_calc_kwargs or {}),
+            )
+            result |= relaxer.calc(structure_in)
             structure_in = result["final_structure"]
 
-        logger.info(
-            "Starting QHA calculation over %d scale factors: %s",
-            len(self.scale_factors),
-            list(self.scale_factors),
-        )
-        properties = self._collect_properties(structure_in)
-
-        # Collected as (n_volumes, n_temps); PhonopyQHA expects (n_temps, n_volumes).
         temperatures = np.arange(self.t_min, self.t_max + self.t_step, self.t_step)
-        free_energy = np.array(properties["free_energies"]).T
-        cv = np.array(properties["heat_capacities"]).T
-        entropy = np.array(properties["entropies"]).T
+        volumes, electronic_energies, free_energies, entropies, heat_capacities = self._collect_properties(structure_in)
 
         qha_results: list[dict] = []
         for pressure in self.pressures:
-            logger.info(
-                "Fitting equation of state and computing QHA thermal properties at pressure=%s GPa",
+            qha = self._create_qha(
+                volumes,
+                electronic_energies,
+                temperatures,  # type: ignore[arg-type]
+                free_energies,
+                entropies,
+                heat_capacities,
                 pressure,
             )
-            qha = PhonopyQHA(
-                volumes=properties["volumes"],
-                electronic_energies=properties["electronic_energies"],
-                temperatures=np.append(temperatures, temperatures[-1] + self.t_step),
-                free_energy=free_energy,
-                cv=cv,
-                entropy=entropy,
-                pressure=pressure,
-                eos=self.eos,
-            )
             self._write_output_files(qha, pressure=pressure)
-            qha_results.append({
-                "pressure": pressure,
-                "qha": qha,
-                "temperatures": temperatures,
-                "thermal_expansion_coefficients": qha.thermal_expansion,
-                "gibbs_free_energies": qha.gibbs_temperature,
-                "bulk_modulus_P": qha.bulk_modulus_temperature,
-                "heat_capacity_P": qha.heat_capacity_P_polyfit,
-                "gruneisen_parameters": qha.gruneisen_temperature,
-            })
+            qha_results.append(self._generate_output_dict(qha, volumes, electronic_energies, temperatures, pressure))
 
-        if self.store_ha_phonon:
-            output_dict["ha"] = properties["ha"]
-            
         output_dict: dict[str, Any] = {
             "pressures": self.pressures,
             "scale_factors": self.scale_factors,
-            "volumes": properties["volumes"],
-            "scaled_structures": properties["scaled_structures"],
-            "electronic_energies": properties["electronic_energies"],
+            "volumes": volumes,
+            "electronic_energies": electronic_energies,
             "qha_results": qha_results,
         }
 
@@ -288,83 +260,32 @@ class QHACalc(PropCalc):
         if len(self.pressures) == 1:
             output_dict |= qha_results[0]
 
-
         return result | output_dict
 
-    def _collect_properties(self, structure: Structure) -> dict[str, list]:
+    def _collect_properties(self, structure: Structure) -> tuple[list, list, list, list, list]:
         """Helper to collect properties like volumes, electronic energies, and thermal properties.
 
         Args:
-            structure: Primitive cell structure at the reference volume.
+            structure: Pymatgen structure for which the properties need to be calculated.
 
         Returns:
-            Dict of lists keyed by ``volumes``, ``electronic_energies``, ``free_energies``,
-            ``entropies``, ``heat_capacities``, ``scaled_structures``, and ``ha``
-            (per-scale-factor ``PhononCalc`` result dicts).
+            Tuple containing lists of volumes, electronic energies, free energies, entropies,
+                and heat capacities for different scale factors.
         """
         volumes = []
         electronic_energies = []
         free_energies = []
         entropies = []
         heat_capacities = []
-        scaled_structures = []
-        ha = []
         for scale_factor in self.scale_factors:
-            # Apply linear strain
-            scaled_structure = self._scale_structure(structure, scale_factor)
-
-            # Relax at fixed volume
-            logger.info("Scale factor %.3f: relaxing at fixed volume", scale_factor)
-            relaxer = RelaxCalc(self.calculator, **self._fixed_cell_relax_calc_kwargs)
-            relaxed_result = relaxer.calc(scaled_structure)
-
-            # Resolve the phonon write path for this scale factor
-            if self.write_ha_phonon is False:
-                write_phonon: bool | str = False
-            elif self.write_ha_phonon is True:
-                write_phonon = f"phonon_{scale_factor:.3f}.yaml"
-            else:
-                write_phonon = str(self.write_ha_phonon).format(scale_factor=scale_factor)
-
-            # Calculate thermal properties from phonon calculation and tabulate results.
-            # We must store the energy, structure, etc. from the phonon calculation if
-            # available in case there are any correction attempts made to resolve imaginary modes,
-            # which would update the relaxation output.
-            logger.info(
-                "Scale factor %.3f: computing phonon thermal properties (V=%.1f Å³)",
-                scale_factor,
-                relaxed_result["final_structure"].volume,
-            )
-            phonon_result = self._calculate_thermal_properties(
-                relaxed_result["final_structure"], write_phonon=write_phonon
-            )
-
-            # Collect properties
-            ha.append(phonon_result)
-            scaled_structures.append(phonon_result["final_structure"])
-            volume = phonon_result["final_structure"].volume
-            if (
-                np.abs(volume - scaled_structure.volume) / scaled_structure.volume > 1e-4  # noqa: PLR2004
-            ):
-                raise ValueError(
-                    f"Somehow the volume changed during relaxation. This is a bug! Before: {scaled_structure.volume}. "
-                    f"After: {volume}"
-                )
-            volumes.append(volume)
-            electronic_energies.append(phonon_result.get("energy", relaxed_result.get("energy")))
-            thermal_properties = phonon_result["thermal_properties"]
+            struct = self._scale_structure(structure, scale_factor)
+            volumes.append(struct.volume)
+            electronic_energies.append(run_pes_calc(struct, self.calculator).energy)
+            thermal_properties = self._calculate_thermal_properties(struct)
             free_energies.append(thermal_properties["free_energy"])
             entropies.append(thermal_properties["entropy"])
             heat_capacities.append(thermal_properties["heat_capacity"])
-        return {
-            "volumes": volumes,
-            "electronic_energies": electronic_energies,
-            "free_energies": free_energies,
-            "entropies": entropies,
-            "heat_capacities": heat_capacities,
-            "scaled_structures": scaled_structures,
-            "ha": ha,
-        }
+        return volumes, electronic_energies, free_energies, entropies, heat_capacities
 
     def _scale_structure(self, structure: Structure, scale_factor: float) -> Structure:
         """Helper to scale the lattice of a structure.
@@ -380,35 +301,62 @@ class QHACalc(PropCalc):
         struct.apply_strain(scale_factor - 1)
         return struct
 
-    def _calculate_thermal_properties(self, structure: Structure, *, write_phonon: bool | str = False) -> dict:
+    def _calculate_thermal_properties(self, structure: Structure) -> dict:
         """Helper to calculate the thermal properties of a structure.
 
         Args:
             structure: Pymatgen structure for which the thermal properties are calculated.
-            write_phonon: Passed directly to ``PhononCalc`` as ``write_phonon``. False disables
-                writing, True uses the phonopy default name, or a string path is used as-is.
 
         Returns:
-            Full result dict from PhononCalc, containing "energy" (eV, from the
-            volume-fixed ionic relaxation) and "thermal_properties" (free energies,
-            entropies and heat capacities).
+            Dictionary of thermal properties containing free energies, entropies and heat capacities.
         """
-        phonon_calc_kwargs = {
-            "t_step": self.t_step,
-            "t_max": self.t_max + self.t_step,  # one extra point for PhonopyQHA finite differences
-            "t_min": self.t_min,
-            "relax_calc_kwargs": self._fixed_cell_relax_calc_kwargs,  # needed for _resolve_imaginary_modes
-            "imaginary_freq_tol": self.imaginary_freq_tol,
-            "on_imaginary_modes": self.on_imaginary_modes,
-            "fix_imaginary_attempts": self.fix_imaginary_attempts,
-            "write_phonon": write_phonon,
-        } | (self.phonon_calc_kwargs or {})
-        phonon_calc_kwargs["relax_structure"] = False  # already relaxed
         phonon_calc = PhononCalc(
             self.calculator,
-            **cast("Any", phonon_calc_kwargs),
+            t_step=self.t_step,
+            t_max=self.t_max,
+            t_min=self.t_min,
+            relax_structure=True,
+            relax_calc_kwargs={"relax_cell": False},
+            write_phonon=False,
+            **(self.phonon_calc_kwargs or {}),
         )
-        return phonon_calc.calc(structure)
+        return phonon_calc.calc(structure)["thermal_properties"]
+
+    def _create_qha(
+        self,
+        volumes: list,
+        electronic_energies: list,
+        temperatures: list,
+        free_energies: list,
+        entropies: list,
+        heat_capacities: list,
+        pressure: None | float,
+    ) -> PhonopyQHA:
+        """Helper to create a PhonopyQHA object for quasi-harmonic approximation.
+
+        Args:
+            volumes: List of volumes corresponding to different scale factors.
+            electronic_energies: List of electronic energies corresponding to different volumes.
+            temperatures: List of temperatures in ascending order (in Kelvin).
+            free_energies: List of free energies corresponding to different volumes and temperatures.
+            entropies: List of entropies corresponding to different volumes and temperatures.
+            heat_capacities: List of heat capacities corresponding to different volumes and temperatures.
+            pressure: Pressure in GPa, or None.
+
+        Returns:
+            Phonopy.qha object.
+        """
+        return PhonopyQHA(
+            volumes=volumes,
+            electronic_energies=electronic_energies,
+            temperatures=temperatures,
+            free_energy=np.transpose(free_energies),
+            cv=np.transpose(heat_capacities),
+            entropy=np.transpose(entropies),
+            pressure=pressure,
+            eos=self.eos,
+            t_max=self.t_max,
+        )
 
     def _write_output_files(self, qha: PhonopyQHA, pressure: float | None = None) -> None:
         """Helper to write various output files based on the QHA calculation.
@@ -417,31 +365,64 @@ class QHACalc(PropCalc):
         before the file extension to avoid overwriting files across pressures.
 
         Args:
-            qha: PhonopyQHA object.
+            qha: Phonopy.qha object.
             pressure: The pressure (GPa) associated with this QHA fit, or None.
         """
 
-        def _suffixed(path: str | os.PathLike) -> str:
+        def _suffixed(path: str) -> str:
             """Insert a pressure suffix before the file extension, only for multi-pressure runs."""
-            if pressure is None or len(self.pressures) == 1:
-                return str(path)
-            s = str(path)
-            stem, dot, ext = s.rpartition(".")
-            return f"{stem}_P{pressure}GPa.{ext}" if stem else f"{s}_P{pressure}GPa"
+            if not path or pressure is None or len(self.pressures) == 1:
+                return path
+            stem, dot, ext = path.rpartition(".")
+            return f"{stem}_P{pressure}GPa.{ext}" if stem else f"{path}_P{pressure}GPa"
 
-        if self.write_helmholtz_volume is not None:
+        if self.write_helmholtz_volume:
             qha.write_helmholtz_volume(filename=_suffixed(self.write_helmholtz_volume))
-        if self.write_volume_temperature is not None:
+        if self.write_volume_temperature:
             qha.write_volume_temperature(filename=_suffixed(self.write_volume_temperature))
-        if self.write_thermal_expansion is not None:
+        if self.write_thermal_expansion:
             qha.write_thermal_expansion(filename=_suffixed(self.write_thermal_expansion))
-        if self.write_gibbs_temperature is not None:
+        if self.write_gibbs_temperature:
             qha.write_gibbs_temperature(filename=_suffixed(self.write_gibbs_temperature))
-        if self.write_bulk_modulus_temperature is not None:
+        if self.write_bulk_modulus_temperature:
             qha.write_bulk_modulus_temperature(filename=_suffixed(self.write_bulk_modulus_temperature))
-        if self.write_heat_capacity_p_numerical is not None:
+        if self.write_heat_capacity_p_numerical:
             qha.write_heat_capacity_P_numerical(filename=_suffixed(self.write_heat_capacity_p_numerical))
-        if self.write_heat_capacity_p_polyfit is not None:
+        if self.write_heat_capacity_p_polyfit:
             qha.write_heat_capacity_P_polyfit(filename=_suffixed(self.write_heat_capacity_p_polyfit))
-        if self.write_gruneisen_temperature is not None:
+        if self.write_gruneisen_temperature:
             qha.write_gruneisen_temperature(filename=_suffixed(self.write_gruneisen_temperature))
+
+    def _generate_output_dict(
+        self,
+        qha: PhonopyQHA,
+        volumes: list,
+        electronic_energies: list,
+        temperatures: list,
+        pressure: float | None,
+    ) -> dict:
+        """Helper to generate a per-pressure output dictionary after QHA calculation.
+
+        Args:
+            qha: Phonopy.qha object.
+            volumes: List of volumes corresponding to different scale factors.
+            electronic_energies: List of electronic energies corresponding to different volumes.
+            temperatures: List of temperatures in ascending order (in Kelvin).
+            pressure: Pressure in GPa, or None.
+
+        Returns:
+            Dictionary containing the results of QHA calculation for this pressure.
+        """
+        return {
+            "pressure": pressure,
+            "qha": qha,
+            "scale_factors": self.scale_factors,
+            "volumes": volumes,
+            "electronic_energies": electronic_energies,
+            "temperatures": temperatures,
+            "thermal_expansion_coefficients": qha.thermal_expansion,
+            "gibbs_free_energies": qha.gibbs_temperature,
+            "bulk_modulus_P": qha.bulk_modulus_temperature,
+            "heat_capacity_P": qha.heat_capacity_P_polyfit,
+            "gruneisen_parameters": qha.gruneisen_temperature,
+        }

--- a/src/matcalc/_qha.py
+++ b/src/matcalc/_qha.py
@@ -272,6 +272,9 @@ class QHACalc(PropCalc):
                 "gruneisen_parameters": qha.gruneisen_temperature,
             })
 
+            if self.store_ha_phonon:
+                output_dict["ha"] = properties["ha"]
+
         output_dict: dict[str, Any] = {
             "pressures": self.pressures,
             "scale_factors": self.scale_factors,
@@ -284,9 +287,6 @@ class QHACalc(PropCalc):
         # Backward-compatible unwrap for the single-pressure case.
         if len(self.pressures) == 1:
             output_dict |= qha_results[0]
-
-        if self.store_ha_phonon:
-            output_dict["ha"] = properties["ha"]
 
         return result | output_dict
 

--- a/src/matcalc/_qha.py
+++ b/src/matcalc/_qha.py
@@ -246,16 +246,18 @@ class QHACalc(PropCalc):
                 t_max=self.t_max,
             )
             self._write_output_files(qha, pressure=pressure)
-            qha_results.append({
-                "pressure": pressure,
-                "qha": qha,
-                "temperatures": temperatures,
-                "thermal_expansion_coefficients": qha.thermal_expansion,
-                "gibbs_free_energies": qha.gibbs_temperature,
-                "bulk_modulus_P": qha.bulk_modulus_temperature,
-                "heat_capacity_P": qha.heat_capacity_P_polyfit,
-                "gruneisen_parameters": qha.gruneisen_temperature,
-            })
+            qha_results.append(
+                {
+                    "pressure": pressure,
+                    "qha": qha,
+                    "temperatures": temperatures,
+                    "thermal_expansion_coefficients": qha.thermal_expansion,
+                    "gibbs_free_energies": qha.gibbs_temperature,
+                    "bulk_modulus_P": qha.bulk_modulus_temperature,
+                    "heat_capacity_P": qha.heat_capacity_P_polyfit,
+                    "gruneisen_parameters": qha.gruneisen_temperature,
+                }
+            )
 
         output_dict: dict[str, Any] = {
             "pressures": self.pressures,

--- a/src/matcalc/_qha.py
+++ b/src/matcalc/_qha.py
@@ -39,7 +39,9 @@ class QHACalc(PropCalc):
     Attributes:
         calculator: ASE calculator or universal model name.
         t_step, t_max, t_min: Temperature grid (K) for QHA output.
-        pressure: Target pressure (GPa) or None.
+        pressure: Target pressure(s) in GPa. Accepts a single float, a list of floats, or
+            None. When multiple pressures are given the expensive phonon calculations are
+            run once and the cheap QHA fitting is repeated per pressure.
         fmax: Relaxation force tolerance (eV/Å).
         max_steps: Max relaxation steps.
         optimizer: ASE optimizer name.
@@ -50,7 +52,14 @@ class QHACalc(PropCalc):
         phonon_calc_kwargs: Kwargs merged into ``PhononCalc``.
         scale_factors: Volume scale factors for the QHA mesh.
         imaginary_freq_tol, on_imaginary_modes, fix_imaginary_attempts: Passed to ``PhononCalc``.
-        write_*: Output paths (or True for defaults) for phonopy QHA text files.
+        store_ha_phonon: Whether to store per-scale-factor harmonic approximation results in
+            the output dict under the ``"ha"`` key.
+        write_ha_phonon: Write per-scale-factor phonopy files. False disables writing,
+            True uses the default name ``phonon_{scale_factor:.3f}.yaml``, or a format string
+            with a ``{scale_factor}`` placeholder selects a custom name.
+        write_*: Output paths (or True for defaults) for phonopy QHA text files. When
+            multiple pressures are requested a ``_P{pressure}GPa`` suffix is inserted before
+            the file extension to avoid overwriting files across pressures.
     """
 
     def __init__(
@@ -60,7 +69,7 @@ class QHACalc(PropCalc):
         t_step: float = 10,
         t_max: float = 1000,
         t_min: float = 0,
-        pressure: None | float = None,
+        pressure: None | float | Sequence[float] = None,
         fmax: float = 1e-5,
         max_steps: int = 5000,
         optimizer: str = "FIRE",
@@ -73,6 +82,8 @@ class QHACalc(PropCalc):
         imaginary_freq_tol: float = -0.01,
         on_imaginary_modes: Literal["error", "warn"] = "warn",
         fix_imaginary_attempts: int = 0,
+        store_ha_phonon: bool = True,
+        write_ha_phonon: bool | str = False,
         write_helmholtz_volume: bool | str | os.PathLike = False,
         write_volume_temperature: bool | str | os.PathLike = False,
         write_thermal_expansion: bool | str | os.PathLike = False,
@@ -88,7 +99,9 @@ class QHACalc(PropCalc):
             t_step: Temperature sampling step (K).
             t_max: Maximum temperature (K).
             t_min: Minimum temperature (K).
-            pressure: Pressure in GPa for Gibbs terms, or None.
+            pressure: Pressure in GPa for Gibbs terms. Accepts a single float, a list of
+                floats, or None. When multiple pressures are supplied the phonon calculations
+                are performed only once and the QHA fit is repeated for each pressure.
             fmax: Force tolerance for relaxations.
             max_steps: Max steps per relaxation.
             optimizer: ASE optimizer name.
@@ -101,6 +114,12 @@ class QHACalc(PropCalc):
             imaginary_freq_tol: Imaginary-mode threshold (THz) for ``PhononCalc``.
             on_imaginary_modes: ``"warn"`` or ``"error"``.
             fix_imaginary_attempts: Imaginary-mode retries per scale factor in ``PhononCalc``.
+            store_ha_phonon: If True (default), each per-scale-factor ``PhononCalc`` result
+                dict is stored and returned under the ``"ha"`` key. Set to False to skip
+                storing these results and omit the ``"ha"`` key from the output entirely.
+            write_ha_phonon: Write a phonopy file for each scale factor. False (default)
+                disables writing. True writes ``phonon_{scale_factor:.3f}.yaml``. A format
+                string containing ``{scale_factor}`` selects a custom filename pattern.
             write_helmholtz_volume: Write F(V); True selects default filename.
             write_volume_temperature: Write V(T).
             write_thermal_expansion: Write thermal expansion alpha(T).
@@ -114,7 +133,6 @@ class QHACalc(PropCalc):
         self.t_step = t_step
         self.t_max = t_max
         self.t_min = t_min
-        self.pressure = pressure
         self.fmax = fmax
         self.max_steps = max_steps
         self.optimizer = optimizer
@@ -127,6 +145,17 @@ class QHACalc(PropCalc):
         self.imaginary_freq_tol = imaginary_freq_tol
         self.on_imaginary_modes = on_imaginary_modes
         self.fix_imaginary_attempts = fix_imaginary_attempts
+        self.store_ha_phonon = store_ha_phonon
+        self.write_ha_phonon = write_ha_phonon
+
+        # Normalize pressure to an internal list; None becomes [None].
+        self.pressure = pressure
+        if pressure is None:
+            self.pressures: list[float | None] = [None]
+        elif isinstance(pressure, (int, float)):
+            self.pressures = [float(pressure)]
+        else:
+            self.pressures = list(pressure)
 
         # Needed to make sure the volume doesn't change during relaxations on scaled structures
         self._fixed_cell_relax_calc_kwargs = {
@@ -178,10 +207,15 @@ class QHACalc(PropCalc):
             structure: Pymatgen structure, ASE atoms, or dict with structure keys.
 
         Returns:
-            Dict with ``qha`` (``PhonopyQHA``), per-volume lists (``scale_factors``, ``volumes``,
-            ``electronic_energies``, ``scaled_structures``), temperature arrays for thermal
-            expansion, Gibbs energy, bulk modulus, Cp, and Gruneisen parameter, merged with any
-            relaxation fields from earlier steps. Units follow phonopy QHA.
+            Dict with per-volume data (``scale_factors``, ``volumes``, ``electronic_energies``,
+            ``scaled_structures``), a ``temperatures`` array, and a ``qha_results`` dict keyed
+            by pressure (``float | None``) whose values each contain ``qha``,
+            ``thermal_expansion_coefficients``, ``gibbs_free_energies``, ``bulk_modulus_P``,
+            ``heat_capacity_P``, and ``gruneisen_parameters``. When only a single pressure was
+            requested the top-level dict also contains those keys directly for backward
+            compatibility. When ``store_ha_phonon=True``, also includes ``"ha"``: a list of
+            per-scale-factor ``PhononCalc`` result dicts. Merged with any relaxation fields
+            from earlier steps. Units follow phonopy QHA.
         """
         result = super().calc(structure)
         structure_in: Structure = to_pmg_structure(result["final_structure"])
@@ -204,34 +238,55 @@ class QHACalc(PropCalc):
         )
         properties = self._collect_properties(structure_in)
 
-        logger.info("Fitting equation of state and computing QHA thermal properties")
+        # Collected as (n_volumes, n_temps); PhonopyQHA expects (n_temps, n_volumes).
         temperatures = np.arange(self.t_min, self.t_max + self.t_step, self.t_step)
-        qha = PhonopyQHA(
-            volumes=properties["volumes"],
-            electronic_energies=properties["electronic_energies"],
-            temperatures=temperatures,
-            free_energy=np.transpose(properties["free_energies"]),
-            cv=np.transpose(properties["heat_capacities"]),
-            entropy=np.transpose(properties["entropies"]),
-            pressure=self.pressure,
-            eos=self.eos,
-            t_max=self.t_max,
-        )
+        free_energy = np.array(properties["free_energies"]).T
+        cv = np.array(properties["heat_capacities"]).T
+        entropy = np.array(properties["entropies"]).T
 
-        self._write_output_files(qha)
-        output_dict = {
-            "qha": qha,
+        qha_results: list[dict] = []
+        for pressure in self.pressures:
+            logger.info(
+                "Fitting equation of state and computing QHA thermal properties at pressure=%s GPa",
+                pressure,
+            )
+            qha = PhonopyQHA(
+                volumes=properties["volumes"],
+                electronic_energies=properties["electronic_energies"],
+                temperatures=np.append(temperatures, temperatures[-1] + self.t_step),
+                free_energy=free_energy,
+                cv=cv,
+                entropy=entropy,
+                pressure=pressure,
+                eos=self.eos,
+            )
+            self._write_output_files(qha, pressure=pressure)
+            qha_results.append({
+                "pressure": pressure,
+                "qha": qha,
+                "temperatures": temperatures,
+                "thermal_expansion_coefficients": qha.thermal_expansion,
+                "gibbs_free_energies": qha.gibbs_temperature,
+                "bulk_modulus_P": qha.bulk_modulus_temperature,
+                "heat_capacity_P": qha.heat_capacity_P_polyfit,
+                "gruneisen_parameters": qha.gruneisen_temperature,
+            })
+
+        output_dict: dict[str, Any] = {
+            "pressures": self.pressures,
             "scale_factors": self.scale_factors,
             "volumes": properties["volumes"],
             "scaled_structures": properties["scaled_structures"],
             "electronic_energies": properties["electronic_energies"],
-            "temperatures": temperatures,
-            "thermal_expansion_coefficients": qha.thermal_expansion,
-            "gibbs_free_energies": qha.gibbs_temperature,
-            "bulk_modulus_P": qha.bulk_modulus_temperature,
-            "heat_capacity_P": qha.heat_capacity_P_polyfit,
-            "gruneisen_parameters": qha.gruneisen_temperature,
+            "qha_results": qha_results,
         }
+
+        # Backward-compatible unwrap for the single-pressure case.
+        if len(self.pressures) == 1:
+            output_dict |= qha_results[0]
+
+        if self.store_ha_phonon:
+            output_dict["ha"] = properties["ha"]
 
         return result | output_dict
 
@@ -243,7 +298,8 @@ class QHACalc(PropCalc):
 
         Returns:
             Dict of lists keyed by ``volumes``, ``electronic_energies``, ``free_energies``,
-            ``entropies``, ``heat_capacities``, and ``scaled_structures``.
+            ``entropies``, ``heat_capacities``, ``scaled_structures``, and ``ha``
+            (per-scale-factor ``PhononCalc`` result dicts).
         """
         volumes = []
         electronic_energies = []
@@ -251,6 +307,7 @@ class QHACalc(PropCalc):
         entropies = []
         heat_capacities = []
         scaled_structures = []
+        ha = []
         for scale_factor in self.scale_factors:
             # Apply linear strain
             scaled_structure = self._scale_structure(structure, scale_factor)
@@ -259,6 +316,14 @@ class QHACalc(PropCalc):
             logger.info("Scale factor %.3f: relaxing at fixed volume", scale_factor)
             relaxer = RelaxCalc(self.calculator, **self._fixed_cell_relax_calc_kwargs)
             relaxed_result = relaxer.calc(scaled_structure)
+
+            # Resolve the phonon write path for this scale factor
+            if self.write_ha_phonon is False:
+                write_phonon: bool | str = False
+            elif self.write_ha_phonon is True:
+                write_phonon = f"phonon_{scale_factor:.3f}.yaml"
+            else:
+                write_phonon = str(self.write_ha_phonon).format(scale_factor=scale_factor)
 
             # Calculate thermal properties from phonon calculation and tabulate results.
             # We must store the energy, structure, etc. from the phonon calculation if
@@ -269,9 +334,12 @@ class QHACalc(PropCalc):
                 scale_factor,
                 relaxed_result["final_structure"].volume,
             )
-            phonon_result = self._calculate_thermal_properties(relaxed_result["final_structure"])
+            phonon_result = self._calculate_thermal_properties(
+                relaxed_result["final_structure"], write_phonon=write_phonon
+            )
 
             # Collect properties
+            ha.append(phonon_result)
             scaled_structures.append(phonon_result["final_structure"])
             volume = phonon_result["final_structure"].volume
             if (
@@ -294,6 +362,7 @@ class QHACalc(PropCalc):
             "entropies": entropies,
             "heat_capacities": heat_capacities,
             "scaled_structures": scaled_structures,
+            "ha": ha,
         }
 
     def _scale_structure(self, structure: Structure, scale_factor: float) -> Structure:
@@ -310,11 +379,13 @@ class QHACalc(PropCalc):
         struct.apply_strain(scale_factor - 1)
         return struct
 
-    def _calculate_thermal_properties(self, structure: Structure) -> dict:
+    def _calculate_thermal_properties(self, structure: Structure, *, write_phonon: bool | str = False) -> dict:
         """Helper to calculate the thermal properties of a structure.
 
         Args:
             structure: Pymatgen structure for which the thermal properties are calculated.
+            write_phonon: Passed directly to ``PhononCalc`` as ``write_phonon``. False disables
+                writing, True uses the phonopy default name, or a string path is used as-is.
 
         Returns:
             Full result dict from PhononCalc, containing "energy" (eV, from the
@@ -323,13 +394,13 @@ class QHACalc(PropCalc):
         """
         phonon_calc_kwargs = {
             "t_step": self.t_step,
-            "t_max": self.t_max,
+            "t_max": self.t_max + self.t_step,  # one extra point for PhonopyQHA finite differences
             "t_min": self.t_min,
             "relax_calc_kwargs": self._fixed_cell_relax_calc_kwargs,  # needed for _resolve_imaginary_modes
             "imaginary_freq_tol": self.imaginary_freq_tol,
             "on_imaginary_modes": self.on_imaginary_modes,
             "fix_imaginary_attempts": self.fix_imaginary_attempts,
-            "write_phonon": False,
+            "write_phonon": write_phonon,
         } | (self.phonon_calc_kwargs or {})
         phonon_calc_kwargs["relax_structure"] = False  # already relaxed
         phonon_calc = PhononCalc(
@@ -338,26 +409,38 @@ class QHACalc(PropCalc):
         )
         return phonon_calc.calc(structure)
 
-    def _write_output_files(self, qha: PhonopyQHA) -> None:
+    def _write_output_files(self, qha: PhonopyQHA, pressure: float | None = None) -> None:
         """Helper to write various output files based on the QHA calculation.
 
+        When multiple pressures are requested, a ``_P{pressure}GPa`` suffix is inserted
+        before the file extension to avoid overwriting files across pressures.
+
         Args:
-            qha: Phonopy.qha object
+            qha: PhonopyQHA object.
+            pressure: The pressure (GPa) associated with this QHA fit, or None.
         """
-        # write_* now are Optional[str | os.PathLike]; None means "do not write".
+
+        def _suffixed(path: str | os.PathLike) -> str:
+            """Insert a pressure suffix before the file extension, only for multi-pressure runs."""
+            if pressure is None or len(self.pressures) == 1:
+                return str(path)
+            s = str(path)
+            stem, dot, ext = s.rpartition(".")
+            return f"{stem}_P{pressure}GPa.{ext}" if stem else f"{s}_P{pressure}GPa"
+
         if self.write_helmholtz_volume is not None:
-            qha.write_helmholtz_volume(filename=self.write_helmholtz_volume)
+            qha.write_helmholtz_volume(filename=_suffixed(self.write_helmholtz_volume))
         if self.write_volume_temperature is not None:
-            qha.write_volume_temperature(filename=self.write_volume_temperature)
+            qha.write_volume_temperature(filename=_suffixed(self.write_volume_temperature))
         if self.write_thermal_expansion is not None:
-            qha.write_thermal_expansion(filename=self.write_thermal_expansion)
+            qha.write_thermal_expansion(filename=_suffixed(self.write_thermal_expansion))
         if self.write_gibbs_temperature is not None:
-            qha.write_gibbs_temperature(filename=self.write_gibbs_temperature)
+            qha.write_gibbs_temperature(filename=_suffixed(self.write_gibbs_temperature))
         if self.write_bulk_modulus_temperature is not None:
-            qha.write_bulk_modulus_temperature(filename=self.write_bulk_modulus_temperature)
+            qha.write_bulk_modulus_temperature(filename=_suffixed(self.write_bulk_modulus_temperature))
         if self.write_heat_capacity_p_numerical is not None:
-            qha.write_heat_capacity_P_numerical(filename=self.write_heat_capacity_p_numerical)
+            qha.write_heat_capacity_P_numerical(filename=_suffixed(self.write_heat_capacity_p_numerical))
         if self.write_heat_capacity_p_polyfit is not None:
-            qha.write_heat_capacity_P_polyfit(filename=self.write_heat_capacity_p_polyfit)
+            qha.write_heat_capacity_P_polyfit(filename=_suffixed(self.write_heat_capacity_p_polyfit))
         if self.write_gruneisen_temperature is not None:
-            qha.write_gruneisen_temperature(filename=self.write_gruneisen_temperature)
+            qha.write_gruneisen_temperature(filename=_suffixed(self.write_gruneisen_temperature))

--- a/src/matcalc/_qha.py
+++ b/src/matcalc/_qha.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import logging
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 from phonopy import PhonopyQHA
@@ -10,16 +11,18 @@ from phonopy import PhonopyQHA
 from ._base import PropCalc
 from ._phonon import PhononCalc
 from ._relaxation import RelaxCalc
-from .backend import run_pes_calc
+from .utils import to_pmg_structure
 
 if TYPE_CHECKING:
+    import os
     from collections.abc import Sequence
-    from pathlib import Path
-    from typing import Any, Literal
+    from typing import Literal
 
     from ase import Atoms
     from ase.calculators.calculator import Calculator
     from pymatgen.core import Structure
+
+logger = logging.getLogger(__name__)
 
 
 class QHACalc(PropCalc):
@@ -33,50 +36,25 @@ class QHACalc(PropCalc):
     and fine-tuning various calculation parameters. Calculation results can be selectively
     saved to output files.
 
-    :ivar calculator: Calculator instance used for electronic structure or energy calculations.
-    :type calculator: Calculator
-    :ivar t_step: Temperature step size in Kelvin.
-    :type t_step: float
-    :ivar t_max: Maximum temperature in Kelvin.
-    :type t_max: float
-    :ivar t_min: Minimum temperature in Kelvin.
-    :type t_min: float
-    :ivar pressure: Target pressure(s) in GPa. Accepts a single float, a list of floats, or
-        None. When multiple pressures are given the expensive phonon calculations are run once
-        and the cheap QHA fitting is repeated per pressure.
-    :type pressure: float | list[float] | None
-    :ivar fmax: Maximum force threshold for structure relaxation in eV/Å.
-    :type fmax: float
-    :ivar optimizer: Type of optimizer used for structural relaxation.
-    :type optimizer: str
-    :ivar eos: Equation of state used for fitting energy vs. volume data.
-    :type eos: Literal["vinet", "birch_murnaghan", "murnaghan"]
-    :ivar relax_structure: Whether to perform structure relaxation before phonon calculations.
-    :type relax_structure: bool
-    :ivar relax_calc_kwargs: Additional keyword arguments for structure relaxation calculations.
-    :type relax_calc_kwargs: dict | None
-    :ivar phonon_calc_kwargs: Additional keyword arguments for phonon calculations.
-    :type phonon_calc_kwargs: dict | None
-    :ivar scale_factors: List of scale factors for lattice scaling.
-    :type scale_factors: Sequence[float]
-    :ivar write_helmholtz_volume: Path or boolean to control saving Helmholtz free energy vs. volume data.
-    :type write_helmholtz_volume: bool | str | Path
-    :ivar write_volume_temperature: Path or boolean to control saving volume vs. temperature data.
-    :type write_volume_temperature: bool | str | Path
-    :ivar write_thermal_expansion: Path or boolean to control saving thermal expansion coefficient data.
-    :type write_thermal_expansion: bool | str | Path
-    :ivar write_gibbs_temperature: Path or boolean to control saving Gibbs free energy as a function of temperature.
-    :type write_gibbs_temperature: bool | str | Path
-    :ivar write_bulk_modulus_temperature: Path or boolean to control saving bulk modulus vs. temperature data.
-    :type write_bulk_modulus_temperature: bool | str | Path
-    :ivar write_heat_capacity_p_numerical: Path or boolean to control saving numerically calculated heat capacity vs.
-        temperature data.
-    :type write_heat_capacity_p_numerical: bool | str | Path
-    :ivar write_heat_capacity_p_polyfit: Path or boolean to control saving polynomial-fitted heat capacity vs.
-        temperature data.
-    :type write_heat_capacity_p_polyfit: bool | str | Path
-    :ivar write_gruneisen_temperature: Path or boolean to control saving Grüneisen parameter vs. temperature data.
-    :type write_gruneisen_temperature: bool | str | Path
+    Attributes:
+        calculator: ASE calculator or universal model name.
+        t_step, t_max, t_min: Temperature grid (K) for QHA output.
+        pressure: Target pressure(s) in GPa. Accepts a single float, a list of floats, or
+            None. When multiple pressures are given the expensive phonon calculations are run
+            once and the cheap QHA fitting is repeated per pressure.
+        fmax: Relaxation force tolerance (eV/Å).
+        max_steps: Max relaxation steps.
+        optimizer: ASE optimizer name.
+        eos: EOS model for volume-energy fits (``vinet``, ``birch_murnaghan``, ``murnaghan``).
+        allow_shape_change: Allow cell shape change at fixed volume in scaled relaxations.
+        relax_structure: Relax initial structure before the QHA volume scan.
+        relax_calc_kwargs: Kwargs merged into all ``RelaxCalc`` uses.
+        phonon_calc_kwargs: Kwargs merged into ``PhononCalc``.
+        scale_factors: Volume scale factors for the QHA mesh.
+        imaginary_freq_tol, on_imaginary_modes, fix_imaginary_attempts: Passed to ``PhononCalc``.
+        write_*: Output paths (or True for defaults) for phonopy QHA text files. When multiple
+            pressures are requested a ``_P{pressure}GPa`` suffix is inserted before the file
+            extension to avoid overwriting files across pressures.
     """
 
     def __init__(
@@ -86,79 +64,74 @@ class QHACalc(PropCalc):
         t_step: float = 10,
         t_max: float = 1000,
         t_min: float = 0,
-        fmax: float = 0.05,
         pressure: None | float | Sequence[float] = None,
+        fmax: float = 1e-5,
+        max_steps: int = 5000,
         optimizer: str = "FIRE",
         eos: Literal["vinet", "birch_murnaghan", "murnaghan"] = "vinet",
+        allow_shape_change: bool = True,
         relax_structure: bool = True,
         relax_calc_kwargs: dict | None = None,
         phonon_calc_kwargs: dict | None = None,
-        scale_factors: Sequence[float] = tuple(np.arange(0.95, 1.05, 0.01)),
-        write_helmholtz_volume: bool | str | Path = False,
-        write_volume_temperature: bool | str | Path = False,
-        write_thermal_expansion: bool | str | Path = False,
-        write_gibbs_temperature: bool | str | Path = False,
-        write_bulk_modulus_temperature: bool | str | Path = False,
-        write_heat_capacity_p_numerical: bool | str | Path = False,
-        write_heat_capacity_p_polyfit: bool | str | Path = False,
-        write_gruneisen_temperature: bool | str | Path = False,
+        scale_factors: Sequence[float] = (0.95, 0.96, 0.97, 0.98, 0.99, 1.0, 1.01, 1.02, 1.03, 1.04, 1.05),
+        imaginary_freq_tol: float = -0.01,
+        on_imaginary_modes: Literal["error", "warn"] = "warn",
+        fix_imaginary_attempts: int = 0,
+        write_helmholtz_volume: bool | str | os.PathLike = False,
+        write_volume_temperature: bool | str | os.PathLike = False,
+        write_thermal_expansion: bool | str | os.PathLike = False,
+        write_gibbs_temperature: bool | str | os.PathLike = False,
+        write_bulk_modulus_temperature: bool | str | os.PathLike = False,
+        write_heat_capacity_p_numerical: bool | str | os.PathLike = False,
+        write_heat_capacity_p_polyfit: bool | str | os.PathLike = False,
+        write_gruneisen_temperature: bool | str | os.PathLike = False,
     ) -> None:
         """
-        Initializes the class that handles thermal and structural calculations, including atomic
-        structure relaxation, property evaluations, and phononic calculations across temperature
-        ranges. This class is mainly designed to facilitate systematic computations involving
-        temperature-dependent material properties and thermodynamic quantities.
-
-        :param calculator: Calculator object or string indicating the computational engine to use
-            for performing calculations.
-        :param t_step: Step size for the temperature range, given in units of K.
-        :param t_max: Maximum temperature for the calculations, given in units of K.
-        :param t_min: Minimum temperature for the calculations, given in units of K.
-        :param pressure: Pressure in GPa for Gibbs terms. Accepts a single float, a list of
-            floats, or None. When multiple pressures are supplied the phonon calculations are
-            performed only once and the QHA fit is repeated for each pressure.
-        :param fmax: Maximum force convergence criterion for structure relaxation, in force units.
-        :param optimizer: Name of the optimizer to use for structure optimization, default is
-            "FIRE".
-        :param eos: Equation of state to use for calculating energy vs. volume relationships.
-            Default is "vinet".
-        :param relax_structure: A boolean flag indicating whether the atomic structure should be
-            relaxed as part of the computation workflow.
-        :param relax_calc_kwargs: A dictionary containing additional keyword arguments to pass to
-            the relax calculation.
-        :param phonon_calc_kwargs: A dictionary containing additional parameters to pass to the
-            phonon calculation routine.
-        :param scale_factors: A sequence of scale factors for volume scaling during
-            thermodynamic and phononic calculations.
-        :param write_helmholtz_volume: Path, boolean, or string to indicate whether and where
-            to save Helmholtz energy as a function of volume.
-        :param write_volume_temperature: Path, boolean, or string to indicate whether and where
-            to save equilibrium volume as a function of temperature.
-        :param write_thermal_expansion: Path, boolean, or string to indicate whether and where
-            to save the thermal expansion coefficient as a function of temperature.
-        :param write_gibbs_temperature: Path, boolean, or string to indicate whether and where
-            to save Gibbs energy as a function of temperature.
-        :param write_bulk_modulus_temperature: Path, boolean, or string to indicate whether and
-            where to save bulk modulus as a function of temperature.
-        :param write_heat_capacity_p_numerical: Path, boolean, or string to indicate whether and
-            where to save specific heat capacity at constant pressure, calculated numerically.
-        :param write_heat_capacity_p_polyfit: Path, boolean, or string to indicate whether and
-            where to save specific heat capacity at constant pressure, calculated via polynomial
-            fitting.
-        :param write_gruneisen_temperature: Path, boolean, or string to indicate whether and
-            where to save Grüneisen parameter values as a function of temperature.
+        Args:
+            calculator: ASE calculator or universal model name string.
+            t_step: Temperature sampling step (K).
+            t_max: Maximum temperature (K).
+            t_min: Minimum temperature (K).
+            pressure: Pressure in GPa for Gibbs terms. Accepts a single float, a list of
+                floats, or None. When multiple pressures are supplied the phonon calculations
+                are performed only once and the QHA fit is repeated for each pressure.
+            fmax: Force tolerance for relaxations.
+            max_steps: Max steps per relaxation.
+            optimizer: ASE optimizer name.
+            eos: EOS key for ``PhonopyQHA``.
+            allow_shape_change: Allow shape relaxation at constant volume for scaled cells.
+            relax_structure: Relax input once before scanning ``scale_factors``.
+            relax_calc_kwargs: Extra kwargs for every ``RelaxCalc``.
+            phonon_calc_kwargs: Extra kwargs for each ``PhononCalc``.
+            scale_factors: Volume scale factors applied to the relaxed structure.
+            imaginary_freq_tol: Imaginary-mode threshold (THz) for ``PhononCalc``.
+            on_imaginary_modes: ``"warn"`` or ``"error"``.
+            fix_imaginary_attempts: Imaginary-mode retries per scale factor in ``PhononCalc``.
+            write_helmholtz_volume: Write F(V); True selects default filename.
+            write_volume_temperature: Write V(T).
+            write_thermal_expansion: Write thermal expansion alpha(T).
+            write_gibbs_temperature: Write G(T).
+            write_bulk_modulus_temperature: Write B(T).
+            write_heat_capacity_p_numerical: Write Cp(T) numerical.
+            write_heat_capacity_p_polyfit: Write Cp(T) polyfit.
+            write_gruneisen_temperature: Write Gruneisen gamma(T).
         """
         self.calculator = calculator  # type: ignore[assignment]
         self.t_step = t_step
         self.t_max = t_max
         self.t_min = t_min
         self.fmax = fmax
+        self.max_steps = max_steps
         self.optimizer = optimizer
         self.eos = eos
+        self.allow_shape_change = allow_shape_change
         self.relax_structure = relax_structure
         self.relax_calc_kwargs = relax_calc_kwargs
         self.phonon_calc_kwargs = phonon_calc_kwargs
         self.scale_factors = scale_factors
+        self.imaginary_freq_tol = imaginary_freq_tol
+        self.on_imaginary_modes = on_imaginary_modes
+        self.fix_imaginary_attempts = fix_imaginary_attempts
 
         # Normalize pressure to an internal list; None becomes [None].
         # self.pressure preserves the original input for repr/serialization.
@@ -170,90 +143,127 @@ class QHACalc(PropCalc):
         else:
             self.pressures = list(pressure)
 
-        self.write_helmholtz_volume = write_helmholtz_volume
-        self.write_volume_temperature = write_volume_temperature
-        self.write_thermal_expansion = write_thermal_expansion
-        self.write_gibbs_temperature = write_gibbs_temperature
-        self.write_bulk_modulus_temperature = write_bulk_modulus_temperature
-        self.write_heat_capacity_p_numerical = write_heat_capacity_p_numerical
-        self.write_heat_capacity_p_polyfit = write_heat_capacity_p_polyfit
-        self.write_gruneisen_temperature = write_gruneisen_temperature
+        # Needed to make sure the volume doesn't change during relaxations on scaled structures
+        self._fixed_cell_relax_calc_kwargs = {
+            "optimizer": self.optimizer,
+            "fmax": self.fmax,
+            "max_steps": self.max_steps,
+            **(self.relax_calc_kwargs or {}),
+        }
+        self._fixed_cell_relax_calc_kwargs["relax_cell"] = bool(self.allow_shape_change)
+        self._fixed_cell_relax_calc_kwargs["cell_filter_kwargs"] = (
+            {"constant_volume": True} if self.allow_shape_change else {}
+        )
+
+        # Normalize write_* inputs to Optional[str | os.PathLike]:
+        # - True  -> default filename (meaning "write to default file")
+        # - False -> None (disabled)
+        # - str/PathLike -> keep as-is (user-provided path)
+        self.write_helmholtz_volume: str | os.PathLike | None = None
+        self.write_volume_temperature: str | os.PathLike | None = None
+        self.write_thermal_expansion: str | os.PathLike | None = None
+        self.write_gibbs_temperature: str | os.PathLike | None = None
+        self.write_bulk_modulus_temperature: str | os.PathLike | None = None
+        self.write_heat_capacity_p_numerical: str | os.PathLike | None = None
+        self.write_heat_capacity_p_polyfit: str | os.PathLike | None = None
+        self.write_gruneisen_temperature: str | os.PathLike | None = None
+
         for key, val, default_path in (
-            ("write_helmholtz_volume", self.write_helmholtz_volume, "helmholtz_volume.dat"),
-            ("write_volume_temperature", self.write_volume_temperature, "volume_temperature.dat"),
-            ("write_thermal_expansion", self.write_thermal_expansion, "thermal_expansion.dat"),
-            ("write_gibbs_temperature", self.write_gibbs_temperature, "gibbs_temperature.dat"),
-            ("write_bulk_modulus_temperature", self.write_bulk_modulus_temperature, "bulk_modulus_temperature.dat"),
-            ("write_heat_capacity_p_numerical", self.write_heat_capacity_p_numerical, "Cp_temperature.dat"),
-            ("write_heat_capacity_p_polyfit", self.write_heat_capacity_p_polyfit, "Cp_temperature_polyfit.dat"),
-            ("write_gruneisen_temperature", self.write_gruneisen_temperature, "gruneisen_temperature.dat"),
+            ("write_helmholtz_volume", write_helmholtz_volume, "helmholtz_volume.dat"),
+            ("write_volume_temperature", write_volume_temperature, "volume_temperature.dat"),
+            ("write_thermal_expansion", write_thermal_expansion, "thermal_expansion.dat"),
+            ("write_gibbs_temperature", write_gibbs_temperature, "gibbs_temperature.dat"),
+            ("write_bulk_modulus_temperature", write_bulk_modulus_temperature, "bulk_modulus_temperature.dat"),
+            ("write_heat_capacity_p_numerical", write_heat_capacity_p_numerical, "Cp_temperature.dat"),
+            ("write_heat_capacity_p_polyfit", write_heat_capacity_p_polyfit, "Cp_temperature_polyfit.dat"),
+            ("write_gruneisen_temperature", write_gruneisen_temperature, "gruneisen_temperature.dat"),
         ):
-            setattr(self, key, str({True: default_path, False: ""}.get(val, val)))  # type: ignore[arg-type]
+            if val is True:
+                normalized: str | os.PathLike | None = default_path
+            elif val is False:
+                normalized = None
+            else:
+                normalized = val
+            setattr(self, key, normalized)
 
     def calc(self, structure: Structure | Atoms | dict[str, Any]) -> dict:
-        """Calculates thermal properties of Pymatgen structure with phonopy under quasi-harmonic approximation.
+        """Quasi-harmonic thermodynamics via phonopy over a volume scan.
 
         The expensive phonon calculations are performed once across all scale factors.
         The QHA fit is then repeated cheaply for each pressure in ``self.pressures``.
 
         Args:
-            structure: Pymatgen structure.
+            structure: Pymatgen structure, ASE atoms, or dict with structure keys.
 
         Returns:
-        {
-            "pressures": List of pressures in GPa (or [None]),
-            "qha_results": List of per-pressure dicts, each containing:
-                "pressure": pressure in GPa (or None),
-                "qha": Phonopy.qha object,
-                "temperatures": List of temperatures in ascending order (in Kelvin),
-                "thermal_expansion_coefficients": List of volumetric thermal expansion coefficients (in Kelvin^-1),
-                "gibbs_free_energies": List of Gibbs free energies at corresponding temperatures (in eV),
-                "bulk_modulus_P": List of bulk modulus at constant pressure (in GPa),
-                "heat_capacity_P": List of heat capacities at constant pressure (in J/K/mol),
-                "gruneisen_parameters": List of Gruneisen parameters at corresponding temperatures,
-            "scale_factors": List of scale factors of lattice constants,
-            "volumes": List of unit cell volumes at corresponding scale factors (in Angstrom^3),
-            "electronic_energies": List of electronic energies at corresponding volumes (in eV),
-            # When a single pressure is given the per-pressure keys are also present at the
-            # top level for backward compatibility.
-        }
+            Dict with per-volume data (``scale_factors``, ``volumes``, ``electronic_energies``,
+            ``scaled_structures``), a ``pressures`` list, and a ``qha_results`` list of
+            per-pressure dicts each containing ``pressure``, ``qha``, ``temperatures``,
+            ``thermal_expansion_coefficients``, ``gibbs_free_energies``, ``bulk_modulus_P``,
+            ``heat_capacity_P``, and ``gruneisen_parameters``. When only a single pressure was
+            requested the top-level dict also contains those keys directly for backward
+            compatibility. Merged with any relaxation fields from earlier steps.
+            Units follow phonopy QHA.
         """
         result = super().calc(structure)
-        structure_in: Structure = result["final_structure"]
+        structure_in: Structure = to_pmg_structure(result["final_structure"])
 
         if self.relax_structure:
-            relaxer = RelaxCalc(
+            logger.info("Relaxing input structure before QHA")
+            result |= RelaxCalc(
                 self.calculator,
                 fmax=self.fmax,
                 optimizer=self.optimizer,
-                **(self.relax_calc_kwargs or {}),
-            )
-            result |= relaxer.calc(structure_in)
+                max_steps=self.max_steps,
+                **self.relax_calc_kwargs or {},
+            ).calc(structure_in)
             structure_in = result["final_structure"]
 
+        logger.info(
+            "Starting QHA calculation over %d scale factors: %s",
+            len(self.scale_factors),
+            list(self.scale_factors),
+        )
+        properties = self._collect_properties(structure_in)
+
         temperatures = np.arange(self.t_min, self.t_max + self.t_step, self.t_step)
-        volumes, electronic_energies, free_energies, entropies, heat_capacities = self._collect_properties(structure_in)
 
         qha_results: list[dict] = []
         for pressure in self.pressures:
-            qha = self._create_qha(
-                volumes,
-                electronic_energies,
-                temperatures,  # type: ignore[arg-type]
-                free_energies,
-                entropies,
-                heat_capacities,
+            logger.info(
+                "Fitting equation of state and computing QHA thermal properties at pressure=%s GPa",
                 pressure,
             )
+            qha = PhonopyQHA(
+                volumes=properties["volumes"],
+                electronic_energies=properties["electronic_energies"],
+                temperatures=temperatures,
+                free_energy=np.transpose(properties["free_energies"]),
+                cv=np.transpose(properties["heat_capacities"]),
+                entropy=np.transpose(properties["entropies"]),
+                pressure=pressure,
+                eos=self.eos,
+                t_max=self.t_max,
+            )
             self._write_output_files(qha, pressure=pressure)
-            qha_results.append(self._generate_output_dict(qha, volumes, electronic_energies, temperatures, pressure))
+            qha_results.append({
+                "pressure": pressure,
+                "qha": qha,
+                "temperatures": temperatures,
+                "thermal_expansion_coefficients": qha.thermal_expansion,
+                "gibbs_free_energies": qha.gibbs_temperature,
+                "bulk_modulus_P": qha.bulk_modulus_temperature,
+                "heat_capacity_P": qha.heat_capacity_P_polyfit,
+                "gruneisen_parameters": qha.gruneisen_temperature,
+            })
 
         output_dict: dict[str, Any] = {
             "pressures": self.pressures,
-            "scale_factors": self.scale_factors,
-            "volumes": volumes,
-            "electronic_energies": electronic_energies,
             "qha_results": qha_results,
+            "scale_factors": self.scale_factors,
+            "volumes": properties["volumes"],
+            "scaled_structures": properties["scaled_structures"],
+            "electronic_energies": properties["electronic_energies"],
         }
 
         # Backward-compatible unwrap for the single-pressure case.
@@ -262,30 +272,66 @@ class QHACalc(PropCalc):
 
         return result | output_dict
 
-    def _collect_properties(self, structure: Structure) -> tuple[list, list, list, list, list]:
+    def _collect_properties(self, structure: Structure) -> dict[str, list]:
         """Helper to collect properties like volumes, electronic energies, and thermal properties.
 
         Args:
-            structure: Pymatgen structure for which the properties need to be calculated.
+            structure: Primitive cell structure at the reference volume.
 
         Returns:
-            Tuple containing lists of volumes, electronic energies, free energies, entropies,
-                and heat capacities for different scale factors.
+            Dict of lists keyed by ``volumes``, ``electronic_energies``, ``free_energies``,
+            ``entropies``, ``heat_capacities``, and ``scaled_structures``.
         """
         volumes = []
         electronic_energies = []
         free_energies = []
         entropies = []
         heat_capacities = []
+        scaled_structures = []
         for scale_factor in self.scale_factors:
-            struct = self._scale_structure(structure, scale_factor)
-            volumes.append(struct.volume)
-            electronic_energies.append(run_pes_calc(struct, self.calculator).energy)
-            thermal_properties = self._calculate_thermal_properties(struct)
+            # Apply linear strain
+            scaled_structure = self._scale_structure(structure, scale_factor)
+
+            # Relax at fixed volume
+            logger.info("Scale factor %.3f: relaxing at fixed volume", scale_factor)
+            relaxer = RelaxCalc(self.calculator, **self._fixed_cell_relax_calc_kwargs)
+            relaxed_result = relaxer.calc(scaled_structure)
+
+            # Calculate thermal properties from phonon calculation and tabulate results.
+            # We must store the energy, structure, etc. from the phonon calculation if
+            # available in case there are any correction attempts made to resolve imaginary modes,
+            # which would update the relaxation output.
+            logger.info(
+                "Scale factor %.3f: computing phonon thermal properties (V=%.1f Å³)",
+                scale_factor,
+                relaxed_result["final_structure"].volume,
+            )
+            phonon_result = self._calculate_thermal_properties(relaxed_result["final_structure"])
+
+            # Collect properties
+            scaled_structures.append(phonon_result["final_structure"])
+            volume = phonon_result["final_structure"].volume
+            if (
+                np.abs(volume - scaled_structure.volume) / scaled_structure.volume > 1e-4  # noqa: PLR2004
+            ):
+                raise ValueError(
+                    f"Somehow the volume changed during relaxation. This is a bug! Before: {scaled_structure.volume}. "
+                    f"After: {volume}"
+                )
+            volumes.append(volume)
+            electronic_energies.append(phonon_result.get("energy", relaxed_result.get("energy")))
+            thermal_properties = phonon_result["thermal_properties"]
             free_energies.append(thermal_properties["free_energy"])
             entropies.append(thermal_properties["entropy"])
             heat_capacities.append(thermal_properties["heat_capacity"])
-        return volumes, electronic_energies, free_energies, entropies, heat_capacities
+        return {
+            "volumes": volumes,
+            "electronic_energies": electronic_energies,
+            "free_energies": free_energies,
+            "entropies": entropies,
+            "heat_capacities": heat_capacities,
+            "scaled_structures": scaled_structures,
+        }
 
     def _scale_structure(self, structure: Structure, scale_factor: float) -> Structure:
         """Helper to scale the lattice of a structure.
@@ -308,55 +354,26 @@ class QHACalc(PropCalc):
             structure: Pymatgen structure for which the thermal properties are calculated.
 
         Returns:
-            Dictionary of thermal properties containing free energies, entropies and heat capacities.
+            Full result dict from PhononCalc, containing "energy" (eV, from the
+            volume-fixed ionic relaxation) and "thermal_properties" (free energies,
+            entropies and heat capacities).
         """
+        phonon_calc_kwargs = {
+            "t_step": self.t_step,
+            "t_max": self.t_max,
+            "t_min": self.t_min,
+            "relax_calc_kwargs": self._fixed_cell_relax_calc_kwargs,  # needed for _resolve_imaginary_modes
+            "imaginary_freq_tol": self.imaginary_freq_tol,
+            "on_imaginary_modes": self.on_imaginary_modes,
+            "fix_imaginary_attempts": self.fix_imaginary_attempts,
+            "write_phonon": False,
+        } | (self.phonon_calc_kwargs or {})
+        phonon_calc_kwargs["relax_structure"] = False  # already relaxed
         phonon_calc = PhononCalc(
             self.calculator,
-            t_step=self.t_step,
-            t_max=self.t_max,
-            t_min=self.t_min,
-            relax_structure=True,
-            relax_calc_kwargs={"relax_cell": False},
-            write_phonon=False,
-            **(self.phonon_calc_kwargs or {}),
+            **cast("Any", phonon_calc_kwargs),
         )
-        return phonon_calc.calc(structure)["thermal_properties"]
-
-    def _create_qha(
-        self,
-        volumes: list,
-        electronic_energies: list,
-        temperatures: list,
-        free_energies: list,
-        entropies: list,
-        heat_capacities: list,
-        pressure: None | float,
-    ) -> PhonopyQHA:
-        """Helper to create a PhonopyQHA object for quasi-harmonic approximation.
-
-        Args:
-            volumes: List of volumes corresponding to different scale factors.
-            electronic_energies: List of electronic energies corresponding to different volumes.
-            temperatures: List of temperatures in ascending order (in Kelvin).
-            free_energies: List of free energies corresponding to different volumes and temperatures.
-            entropies: List of entropies corresponding to different volumes and temperatures.
-            heat_capacities: List of heat capacities corresponding to different volumes and temperatures.
-            pressure: Pressure in GPa, or None.
-
-        Returns:
-            Phonopy.qha object.
-        """
-        return PhonopyQHA(
-            volumes=volumes,
-            electronic_energies=electronic_energies,
-            temperatures=temperatures,
-            free_energy=np.transpose(free_energies),
-            cv=np.transpose(heat_capacities),
-            entropy=np.transpose(entropies),
-            pressure=pressure,
-            eos=self.eos,
-            t_max=self.t_max,
-        )
+        return phonon_calc.calc(structure)
 
     def _write_output_files(self, qha: PhonopyQHA, pressure: float | None = None) -> None:
         """Helper to write various output files based on the QHA calculation.
@@ -369,60 +386,28 @@ class QHACalc(PropCalc):
             pressure: The pressure (GPa) associated with this QHA fit, or None.
         """
 
-        def _suffixed(path: str) -> str:
+        def _suffixed(path: str | os.PathLike) -> str | os.PathLike:
             """Insert a pressure suffix before the file extension, only for multi-pressure runs."""
-            if not path or pressure is None or len(self.pressures) == 1:
+            if pressure is None or len(self.pressures) == 1:
                 return path
-            stem, dot, ext = path.rpartition(".")
-            return f"{stem}_P{pressure}GPa.{ext}" if stem else f"{path}_P{pressure}GPa"
+            s = str(path)
+            stem, dot, ext = s.rpartition(".")
+            return f"{stem}_P{pressure}GPa.{ext}" if stem else f"{s}_P{pressure}GPa"
 
-        if self.write_helmholtz_volume:
+        # write_* are Optional[str | os.PathLike]; None means "do not write".
+        if self.write_helmholtz_volume is not None:
             qha.write_helmholtz_volume(filename=_suffixed(self.write_helmholtz_volume))
-        if self.write_volume_temperature:
+        if self.write_volume_temperature is not None:
             qha.write_volume_temperature(filename=_suffixed(self.write_volume_temperature))
-        if self.write_thermal_expansion:
+        if self.write_thermal_expansion is not None:
             qha.write_thermal_expansion(filename=_suffixed(self.write_thermal_expansion))
-        if self.write_gibbs_temperature:
+        if self.write_gibbs_temperature is not None:
             qha.write_gibbs_temperature(filename=_suffixed(self.write_gibbs_temperature))
-        if self.write_bulk_modulus_temperature:
+        if self.write_bulk_modulus_temperature is not None:
             qha.write_bulk_modulus_temperature(filename=_suffixed(self.write_bulk_modulus_temperature))
-        if self.write_heat_capacity_p_numerical:
+        if self.write_heat_capacity_p_numerical is not None:
             qha.write_heat_capacity_P_numerical(filename=_suffixed(self.write_heat_capacity_p_numerical))
-        if self.write_heat_capacity_p_polyfit:
+        if self.write_heat_capacity_p_polyfit is not None:
             qha.write_heat_capacity_P_polyfit(filename=_suffixed(self.write_heat_capacity_p_polyfit))
-        if self.write_gruneisen_temperature:
+        if self.write_gruneisen_temperature is not None:
             qha.write_gruneisen_temperature(filename=_suffixed(self.write_gruneisen_temperature))
-
-    def _generate_output_dict(
-        self,
-        qha: PhonopyQHA,
-        volumes: list,
-        electronic_energies: list,
-        temperatures: list,
-        pressure: float | None,
-    ) -> dict:
-        """Helper to generate a per-pressure output dictionary after QHA calculation.
-
-        Args:
-            qha: Phonopy.qha object.
-            volumes: List of volumes corresponding to different scale factors.
-            electronic_energies: List of electronic energies corresponding to different volumes.
-            temperatures: List of temperatures in ascending order (in Kelvin).
-            pressure: Pressure in GPa, or None.
-
-        Returns:
-            Dictionary containing the results of QHA calculation for this pressure.
-        """
-        return {
-            "pressure": pressure,
-            "qha": qha,
-            "scale_factors": self.scale_factors,
-            "volumes": volumes,
-            "electronic_energies": electronic_energies,
-            "temperatures": temperatures,
-            "thermal_expansion_coefficients": qha.thermal_expansion,
-            "gibbs_free_energies": qha.gibbs_temperature,
-            "bulk_modulus_P": qha.bulk_modulus_temperature,
-            "heat_capacity_P": qha.heat_capacity_P_polyfit,
-            "gruneisen_parameters": qha.gruneisen_temperature,
-        }

--- a/src/matcalc/_qha.py
+++ b/src/matcalc/_qha.py
@@ -246,27 +246,8 @@ class QHACalc(PropCalc):
                 pressure,
             )
             self._write_output_files(qha, pressure=pressure)
-<<<<<<< HEAD
             qha_results.append(self._generate_output_dict(qha, volumes, electronic_energies, temperatures, pressure))
 
-=======
-            qha_results.append(
-                {
-                    "pressure": pressure,
-                    "qha": qha,
-                    "temperatures": temperatures,
-                    "thermal_expansion_coefficients": qha.thermal_expansion,
-                    "gibbs_free_energies": qha.gibbs_temperature,
-                    "bulk_modulus_P": qha.bulk_modulus_temperature,
-                    "heat_capacity_P": qha.heat_capacity_P_polyfit,
-                    "gruneisen_parameters": qha.gruneisen_temperature,
-                }
-            )
-
-        if self.store_ha_phonon:
-            output_dict["ha"] = properties["ha"]
-
->>>>>>> origin/pressures
         output_dict: dict[str, Any] = {
             "pressures": self.pressures,
             "scale_factors": self.scale_factors,
@@ -409,7 +390,6 @@ class QHACalc(PropCalc):
             qha.write_heat_capacity_P_numerical(filename=_suffixed(self.write_heat_capacity_p_numerical))
         if self.write_heat_capacity_p_polyfit:
             qha.write_heat_capacity_P_polyfit(filename=_suffixed(self.write_heat_capacity_p_polyfit))
-<<<<<<< HEAD
         if self.write_gruneisen_temperature:
             qha.write_gruneisen_temperature(filename=_suffixed(self.write_gruneisen_temperature))
 
@@ -446,7 +426,3 @@ class QHACalc(PropCalc):
             "heat_capacity_P": qha.heat_capacity_P_polyfit,
             "gruneisen_parameters": qha.gruneisen_temperature,
         }
-=======
-        if self.write_gruneisen_temperature is not None:
-            qha.write_gruneisen_temperature(filename=_suffixed(self.write_gruneisen_temperature))
->>>>>>> origin/pressures

--- a/src/matcalc/_qha.py
+++ b/src/matcalc/_qha.py
@@ -275,7 +275,7 @@ class QHACalc(PropCalc):
             )
 
             if self.store_ha_phonon:
-                output_dict["ha"] = properties["ha"]
+                qha_results["ha"] = properties["ha"]
 
         output_dict: dict[str, Any] = {
             "pressures": self.pressures,

--- a/tests/test_qha.py
+++ b/tests/test_qha.py
@@ -287,3 +287,49 @@ def test_qha_calc_fix_imaginary_attempts(
         qha_calc.calc(distorted_si_atoms)
     assert any("Imaginary mode correction attempt" in r.message for r in caplog.records)
     caplog.clear()
+
+def test_qha_multiple_pressures(
+    Li2O: Structure,
+    matpes_calculator: PESCalculator,
+) -> None:
+    """Tests for QHACalc class with pressure parameter."""
+    # Initialize QHACalc
+    qha_calc = QHACalc(
+        calculator=matpes_calculator,
+        t_step=50,
+        t_max=1000,
+        fmax=0.05,
+        scale_factors=[0.97, 0.98, 0.99, 1.00, 1.01, 1.02, 1.03],
+        pressure=[1.0, 10.0],
+        phonon_calc_kwargs={"supercell_matrix": ((2, 0, 0), (0, 2, 0), (0, 0, 2))},
+    )
+
+    result = qha_calc.calc(Li2O)
+
+    # Test values corresponding to different scale factors
+    assert result["volumes"] == pytest.approx(
+        [23.07207, 23.79302, 24.52884, 25.27967, 26.04567, 26.82699, 27.62378],
+        abs=1e-1,
+    )
+
+    assert result["electronic_energies"] == pytest.approx(
+        [
+            -14.043658256530762,
+            -14.065637588500977,
+            -14.07603645324707,
+            -14.07599925994873,
+            -14.066689491271973,
+            -14.048959732055664,
+            -14.023341178894043,
+        ],
+        abs=1e-2,
+    )
+
+    assert len(result["qha_results"]) == 2
+    assert result["qha_results"][0]["pressure"] == 1.0
+    assert result["qha_results"][0]["pressure"] == 10.0
+
+    # Test values at 300 K
+    ind = result["temperatures"].tolist().index(300)
+    assert result["qha_results"][0]["gibbs_free_energies"][ind] == pytest.approx(-13.783952868872804, rel=1e-1)
+    assert result["qha_results"][1]["gibbs_free_energies"][ind] == pytest.approx(-12.43074657443325, rel=1e-1)

--- a/tests/test_qha.py
+++ b/tests/test_qha.py
@@ -288,6 +288,7 @@ def test_qha_calc_fix_imaginary_attempts(
     assert any("Imaginary mode correction attempt" in r.message for r in caplog.records)
     caplog.clear()
 
+
 def test_qha_multiple_pressures(
     Li2O: Structure,
     matpes_calculator: PESCalculator,

--- a/tests/test_qha.py
+++ b/tests/test_qha.py
@@ -327,7 +327,7 @@ def test_qha_multiple_pressures(
 
     assert len(result["qha_results"]) == 2
     assert result["qha_results"][0]["pressure"] == 1.0
-    assert result["qha_results"][0]["pressure"] == 10.0
+    assert result["qha_results"][1]["pressure"] == 10.0
 
     # Test values at 300 K
     ind = result["temperatures"].tolist().index(300)


### PR DESCRIPTION
## Summary
Closes #202 by allowing for a list of pressures to be passed to `QHACalc`. 

## Checklist

- [X] Google format doc strings added. Check with `ruff`.
- [X] Type annotations included. Check with `mypy`.
- [X] Tests added for new features/fixes.
- [X] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
