### PR TITLE
Set `primitive_matrix="auto"` in `Phonopy` calls

### DIFF
--- a/src/matcalc/_phonon.py
+++ b/src/matcalc/_phonon.py
@@ -196,7 +196,7 @@ class PhononCalc(PropCalc):
         else:
             supercell_matrix = np.diag(np.ceil(self.min_length / np.array(structure.lattice.abc)).astype(int))
 
-        phonon = phonopy.Phonopy(cell, supercell_matrix=supercell_matrix)
+        phonon = phonopy.Phonopy(cell, supercell_matrix=supercell_matrix, primitive_matrix="auto")
         phonon.generate_displacements(distance=self.atom_disp)
         disp_supercells = [
             get_pmg_structure(supercell)


### PR DESCRIPTION
This PR resolves https://github.com/materialyzeai/matcalc/issues/200 by setting `primitive_matrix="auto"` in the `Phonopy` call within `PhononCalc`. I am having trouble identifying a minimal example to test this fix, but I hope this simple PR can be merged without a specific test.

## Checklist

- [X] Google format doc strings added. Check with `ruff`.
- [X] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [X] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
