### PR TITLE
Replace warning with logger for max steps reached

### DIFF
--- a/src/matcalc/backend/_ase.py
+++ b/src/matcalc/backend/_ase.py
@@ -134,7 +134,7 @@ def run_ase(
             if traj is not None:
                 traj.close()
             if opt.nsteps >= max_steps:
-                warnings.warn("Maximum steps reached in structure relaxation.", UserWarning, stacklevel=2)
+                logger.warning("Maximum steps reached in structure relaxation.")
 
         if relax_cell:
             atoms = atoms.atoms  # type:ignore[attr-defined]

--- a/src/matcalc/backend/_ase.py
+++ b/src/matcalc/backend/_ase.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import contextlib
 import io
 import logging
-import warnings
 from inspect import isclass
 from typing import TYPE_CHECKING
 


### PR DESCRIPTION
## Summary
Use the `logging` module for warnings to be consistent with the rest of matcalc and for observing best practices.