### PR TITLE
Extract PropCalc._prerelax; fold relax boilerplate

### DIFF
--- a/src/matcalc/_adsorption.py
+++ b/src/matcalc/_adsorption.py
@@ -348,6 +348,13 @@ class AdsorptionCalc(PropCalc):
         Returns:
             Dict including ``adsorption_energy`` and merged slab/adsorbate fields.
         """
+        if not isinstance(structure, dict):
+            msg = (
+                "For adsorption calculations, structure must be a dict with keys "
+                "'adslab', 'slab', and 'adsorbate' (and optionally 'slab_energy_per_atom' "
+                "and/or 'adsorbate_energy'). Use calc_adslabs(...) to generate input dicts."
+            )
+            raise TypeError(msg)
         result_dict = structure.copy()
 
         result_dict |= self.calc_adsorbate(

--- a/src/matcalc/_base.py
+++ b/src/matcalc/_base.py
@@ -78,6 +78,50 @@ class PropCalc(abc.ABC):
         base: dict = prev.get("_units", prev) if isinstance(prev, dict) else {}
         return {**base, **new}
 
+    def _prerelax(
+        self,
+        structure: Structure | Atoms,
+        result: dict[str, Any],
+        relaxer: PropCalc | None = None,
+        **relax_kwargs: Any,
+    ) -> tuple[dict[str, Any], Structure | Atoms]:
+        """Optionally relax ``structure`` and merge the relaxation result.
+
+        Centralises the ``if self.relax_structure: ... else ...`` pattern shared
+        by most property calculators. Honors ``self.relax_structure``; when False
+        (or absent), the input is returned unchanged.
+
+        Pass ``relaxer`` to reuse a single ``RelaxCalc`` instance across multiple
+        calls (e.g. relaxing the parent structure and then deformed structures
+        with different settings); otherwise pass relaxation kwargs and a fresh
+        ``RelaxCalc`` is constructed using ``self.calculator``.
+
+        Args:
+            structure: Input structure (already extracted from the result dict).
+            result: The current result dict; relaxation outputs are merged in.
+            relaxer: Pre-configured ``RelaxCalc``-like instance. Mutually
+                exclusive with ``relax_kwargs``.
+            **relax_kwargs: Forwarded to ``RelaxCalc`` when ``relaxer`` is None.
+                ``relax_calc_kwargs`` on the subclass (if any) takes precedence
+                over these, mirroring the existing per-calc convention.
+
+        Returns:
+            ``(result, structure)`` — both updated when a relaxation ran, both
+            unchanged otherwise.
+        """
+        if not getattr(self, "relax_structure", False):
+            return result, structure
+        if relaxer is None:
+            # Lazy import: RelaxCalc imports from _base, so we can't import it
+            # at module scope without a circular import.
+            from ._relaxation import RelaxCalc
+
+            extra = getattr(self, "relax_calc_kwargs", None) or {}
+            relaxer = RelaxCalc(self.calculator, **{**relax_kwargs, **extra})
+        relax_result = relaxer.calc(structure)
+        merged = {**result, **relax_result}
+        return merged, relax_result["final_structure"]
+
     @abc.abstractmethod
     def calc(self, structure: Structure | Atoms | dict[str, Any]) -> dict[str, Any]:
         """

--- a/src/matcalc/_elasticity.py
+++ b/src/matcalc/_elasticity.py
@@ -113,15 +113,14 @@ class ElasticityCalc(PropCalc):
             ``_units`` is a dict mapping each numeric output to its unit string.
         """
         result = super().calc(structure)
-        structure_in: Structure | Atoms = result["final_structure"]
+        structure_in = result["final_structure"]
 
+        relax_calc: RelaxCalc | None = None
         if self.relax_structure or self.relax_deformed_structures:
             relax_calc = RelaxCalc(self.calculator, fmax=self.fmax, **(self.relax_calc_kwargs or {}))
-            if self.relax_structure:
-                result |= relax_calc.calc(structure_in)
-                structure_in = result["final_structure"]
-            if self.relax_deformed_structures:
-                relax_calc.relax_cell = False
+        result, structure_in = self._prerelax(structure_in, result, relaxer=relax_calc)
+        if self.relax_deformed_structures and relax_calc is not None:
+            relax_calc.relax_cell = False
 
         deformed_structure_set = DeformedStructureSet(
             to_pmg_structure(structure_in),
@@ -131,8 +130,8 @@ class ElasticityCalc(PropCalc):
         )
         stresses = []
         for deformed_structure in deformed_structure_set:
-            if self.relax_deformed_structures:
-                deformed_relaxed = relax_calc.calc(deformed_structure)["final_structure"]  # pyright:ignore (reportPossiblyUnboundVariable)
+            if self.relax_deformed_structures and relax_calc is not None:
+                deformed_relaxed = relax_calc.calc(deformed_structure)["final_structure"]
                 sim = run_pes_calc(deformed_relaxed, self.calculator)
             else:
                 sim = run_pes_calc(deformed_structure, self.calculator)

--- a/src/matcalc/_eos.py
+++ b/src/matcalc/_eos.py
@@ -100,18 +100,18 @@ class EOSCalc(PropCalc):
             ``BirchMurnaghan`` / ``EOSBase`` for fit details.
         """
         result = super().calc(structure)
-        structure_in: Structure = to_pmg_structure(result["final_structure"])
         relax_calc_kwargs = {
             "optimizer": self.optimizer,
             "fmax": self.fmax,
             "max_steps": self.max_steps,
             **(self.relax_calc_kwargs or {}),
         }
-
-        if self.relax_structure:
-            relaxer = RelaxCalc(self.calculator, **relax_calc_kwargs)
-            result |= relaxer.calc(structure_in)
-            structure_in = result["final_structure"]
+        result, raw_structure = self._prerelax(
+            result["final_structure"],
+            result,
+            relaxer=RelaxCalc(self.calculator, **relax_calc_kwargs),
+        )
+        structure_in: Structure = to_pmg_structure(raw_structure)
 
         volumes, energies = [], []
 

--- a/src/matcalc/_md.py
+++ b/src/matcalc/_md.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 import tempfile
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 from ase import Atoms, units
@@ -21,7 +21,6 @@ from ase.md.velocitydistribution import MaxwellBoltzmannDistribution, Stationary
 from ase.md.verlet import VelocityVerlet
 
 from ._base import PropCalc
-from ._relaxation import RelaxCalc
 from .utils import to_ase_atoms, to_pmg_structure
 
 if TYPE_CHECKING:
@@ -356,24 +355,16 @@ class MDCalc(PropCalc):
         # Preprocess the input structure using the superclass's calc method.
         # This initial processing returns a dictionary containing a "final_structure".
         result = super().calc(structure)
-        structure_in: Structure = result["final_structure"]
-
-        # If structure relaxation is enabled, relax the structure (atoms only) before the MD simulation.
-        if self.relax_structure:
-            # Create a RelaxCalc instance with the specified calculator, convergence criteria (fmax),
-            # optimizer, and any additional keyword arguments for the relaxation calculation.
-            merged_relax_calc_kwargs = {
-                "fmax": self.fmax,
-                "optimizer": self.optimizer,
-                "relax_atoms": True,
-                "relax_cell": False,
-            } | (self.relax_calc_kwargs or {})
-
-            relaxer = RelaxCalc(self.calculator, **cast("Any", merged_relax_calc_kwargs))
-            # Run the relaxation calculation and update the result dictionary.
-            result |= relaxer.calc(structure_in)
-            # Update the input structure with the relaxed final structure.
-            structure_in = result["final_structure"]
+        # If structure relaxation is enabled, relax the structure (atoms only,
+        # fixed cell) before the MD simulation.
+        result, structure_in = self._prerelax(
+            result["final_structure"],
+            result,
+            fmax=self.fmax,
+            optimizer=self.optimizer,
+            relax_atoms=True,
+            relax_cell=False,
+        )
 
         # Convert the structure to an ASE atoms object,
         # which is required for subsequent molecular dynamics (MD) simulation.

--- a/src/matcalc/_phonon3.py
+++ b/src/matcalc/_phonon3.py
@@ -11,7 +11,6 @@ from phono3py import Phono3py
 from pymatgen.io.phonopy import get_phonopy_structure, get_pmg_structure
 
 from ._base import PropCalc
-from ._relaxation import RelaxCalc
 from .backend import run_pes_calc
 from .utils import to_pmg_structure
 
@@ -138,17 +137,12 @@ class Phonon3Calc(PropCalc):
             See phono3py RTA documentation for details.
         """
         result = super().calc(structure)
-        structure_in: Structure = result["final_structure"]
-
-        if self.relax_structure:
-            relaxer = RelaxCalc(
-                self.calculator,
-                fmax=self.fmax,
-                optimizer=self.optimizer,
-                **(self.relax_calc_kwargs or {}),
-            )
-            result |= relaxer.calc(structure_in)
-            structure_in = result["final_structure"]
+        result, structure_in = self._prerelax(
+            result["final_structure"],
+            result,
+            fmax=self.fmax,
+            optimizer=self.optimizer,
+        )
 
         cell = get_phonopy_structure(to_pmg_structure(structure_in))
         phonon3 = Phono3py(

--- a/src/matcalc/_qha.py
+++ b/src/matcalc/_qha.py
@@ -221,18 +221,16 @@ class QHACalc(PropCalc):
             to its unit string. Merged with any relaxation fields from earlier steps.
         """
         result = super().calc(structure)
-        structure_in: Structure = to_pmg_structure(result["final_structure"])
-
         if self.relax_structure:
             logger.info("Relaxing input structure before QHA")
-            result |= RelaxCalc(
-                self.calculator,
-                fmax=self.fmax,
-                optimizer=self.optimizer,
-                max_steps=self.max_steps,
-                **self.relax_calc_kwargs or {},
-            ).calc(structure_in)
-            structure_in = result["final_structure"]
+        result, raw_structure = self._prerelax(
+            result["final_structure"],
+            result,
+            fmax=self.fmax,
+            optimizer=self.optimizer,
+            max_steps=self.max_steps,
+        )
+        structure_in: Structure = to_pmg_structure(raw_structure)
 
         logger.info(
             "Starting QHA calculation over %d scale factors: %s",

--- a/src/matcalc/_stability.py
+++ b/src/matcalc/_stability.py
@@ -81,7 +81,6 @@ class EnergeticsCalc(PropCalc):
             and other keys from relaxation / PES when applicable.
         """
         result = super().calc(structure)
-        structure_in: Structure | Atoms = result["final_structure"]
         relaxer = RelaxCalc(
             self.calculator,
             fmax=self.fmax,
@@ -89,12 +88,8 @@ class EnergeticsCalc(PropCalc):
             perturb_distance=self.perturb_distance,
             **(self.relax_calc_kwargs or {}),
         )
-        if self.relax_structure:
-            result |= relaxer.calc(structure_in)
-            structure_in = result["final_structure"]
-            energy = result["energy"]
-        else:
-            energy = run_pes_calc(structure_in, self.calculator).energy
+        result, structure_in = self._prerelax(result["final_structure"], result, relaxer=relaxer)
+        energy = result["energy"] if self.relax_structure else run_pes_calc(structure_in, self.calculator).energy
         nsites = len(structure_in)
 
         def get_gs_energy(el: Element | Species) -> float:


### PR DESCRIPTION
## Summary

Follow-up to #217. Centralises the
```python
if self.relax_structure:
    relaxer = RelaxCalc(self.calculator, ...)
    result |= relaxer.calc(structure)
    structure = result['final_structure']
```
pattern that every property calculator was duplicating into a single
`PropCalc._prerelax(...)` helper. Each calc keeps its own relax-kwargs
surface but routes the conditional + merge through the helper, giving
one place to fix relax-related bugs in future.

### What's in
- New `PropCalc._prerelax(structure, result, relaxer=None, **kw)`.
  Either takes a pre-built `RelaxCalc` (for `ElasticityCalc` which
  reuses one across parent + deformed-structure relaxations) or
  constructs one lazily from kwargs. Lazy import of `RelaxCalc` avoids
  the circular import.
- Refactored onto the helper: `_phonon3.py`, `_eos.py`, `_qha.py`,
  `_md.py`, `_stability.py`, `_elasticity.py`.

### What's deliberately out
- `_phonon.py` already factors its own private `_relax_structure`
  helper — no win from routing it through `_prerelax`.
- `_surface.py` / `_gb.py` / `_interface.py` / `_adsorption.py` use
  domain-specific flags (`relax_bulk`, `relax_slab`,
  `relax_adsorbate`, etc.) instead of a single `relax_structure`, so
  they don't share the helper's contract.

### Other small consistency fix
- `AdsorptionCalc.calc()` now raises `TypeError` with a clear message
  when given a non-dict input (was an opaque `AttributeError` /
  `KeyError` deep in the call); matches the existing check in
  `InterfaceCalc.calc()`.

## Test plan
- [x] `ruff check src tests`, `ruff format --check`, `mypy -p matcalc` clean
- [x] `pytest tests --ignore=tests/test_lammps.py` — 106 passed, 38 skipped
- [ ] CI matrix (matgl / mace / grace) still loads cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)