### PR TITLE
Correctness + polish batch (audit themes 1, 3.7, 5)

### DIFF
--- a/src/matcalc/__init__.py
+++ b/src/matcalc/__init__.py
@@ -2,12 +2,8 @@
 
 from __future__ import annotations
 
+import logging
 from importlib.metadata import PackageNotFoundError, version
-
-try:
-    __version__ = version("matcalc")
-except PackageNotFoundError:
-    pass  # package not installed
 
 from ._adsorption import AdsorptionCalc
 from ._base import ChainedCalc, PropCalc
@@ -27,6 +23,43 @@ from ._surface import SurfaceCalc
 from .config import SIMULATION_BACKEND, clear_cache
 from .utils import UNIVERSAL_CALCULATOR_NAMES, UNIVERSAL_CALCULATORS, PESCalculator
 
+# Library convention: attach a NullHandler so that matcalc.* loggers are silent
+# unless an application explicitly configures logging. Without this, Python
+# would emit a "no handlers could be found" warning for any log call.
+logging.getLogger(__name__).addHandler(logging.NullHandler())
+
+try:
+    __version__ = version("matcalc")
+except PackageNotFoundError:
+    pass  # package not installed
+
 # Provide an alias for loading calculators quickly.
 load_up = PESCalculator.load_universal
 load_fp = PESCalculator.load_universal
+
+__all__ = [
+    "MEP",
+    "SIMULATION_BACKEND",
+    "UNIVERSAL_CALCULATORS",
+    "UNIVERSAL_CALCULATOR_NAMES",
+    "AdsorptionCalc",
+    "ChainedCalc",
+    "EOSCalc",
+    "ElasticityCalc",
+    "EnergeticsCalc",
+    "GBCalc",
+    "InterfaceCalc",
+    "LAMMPSMDCalc",
+    "MDCalc",
+    "NEBCalc",
+    "PESCalculator",
+    "Phonon3Calc",
+    "PhononCalc",
+    "PropCalc",
+    "QHACalc",
+    "RelaxCalc",
+    "SurfaceCalc",
+    "clear_cache",
+    "load_fp",
+    "load_up",
+]

--- a/src/matcalc/_adsorption.py
+++ b/src/matcalc/_adsorption.py
@@ -43,6 +43,7 @@ class AdsorptionCalc(PropCalc):
         fmax: float = 0.1,
         optimizer: str | Optimizer = "BFGS",
         max_steps: int = 500,
+        adsorbate_vacuum_size: float = 15.0,
         relax_calc_kwargs: dict[str, Any] | None = None,
     ) -> None:
         """
@@ -54,6 +55,10 @@ class AdsorptionCalc(PropCalc):
             fmax: Force tolerance (eV/Å).
             optimizer: ASE optimizer name or class.
             max_steps: Max relaxation steps.
+            adsorbate_vacuum_size: Padding (Å) added on each side of the adsorbate's
+                bounding box when building the isolated-adsorbate relaxation cell.
+                Increase for large or charged adsorbates to avoid spurious
+                image-image interactions. Default 15.
             relax_calc_kwargs: Optional kwargs for ``RelaxCalc``.
         """
         self.calculator = calculator  # type: ignore[assignment]
@@ -63,6 +68,7 @@ class AdsorptionCalc(PropCalc):
         self.fmax = fmax
         self.optimizer = optimizer
         self.max_steps = max_steps
+        self.adsorbate_vacuum_size = adsorbate_vacuum_size
         self.relax_calc_kwargs = relax_calc_kwargs
 
         self.final_bulk: Structure | None = None
@@ -131,8 +137,11 @@ class AdsorptionCalc(PropCalc):
             )
 
             adsorbate = to_ase_atoms(adsorbate)
-            # Add 15 Å of vacuum in all directions for relaxation
-            adsorbate.set_cell(np.max(adsorbate.positions, axis=0) - np.min(adsorbate.positions, axis=0) + 15)
+            # Pad the adsorbate's bounding box by ``adsorbate_vacuum_size`` Å on each
+            # axis to suppress image-image interactions during the isolated relaxation.
+            adsorbate.set_cell(
+                np.max(adsorbate.positions, axis=0) - np.min(adsorbate.positions, axis=0) + self.adsorbate_vacuum_size
+            )
             adsorbate_opt = relaxer.calc(adsorbate)
         else:
             adsorbate_opt = {

--- a/src/matcalc/_base.py
+++ b/src/matcalc/_base.py
@@ -29,6 +29,16 @@ class PropCalc(abc.ABC):
     on multiple structures using joblib.
     """
 
+    def __repr__(self) -> str:
+        """Concise repr — class name and the underlying calculator's class.
+
+        Useful for logging / reproducibility; subclasses can override to expose
+        their key knobs (e.g. fmax, supercell, scale_factors).
+        """
+        calc = getattr(self, "_pes_calculator", None)
+        calc_name = type(calc).__name__ if calc is not None else "<no calculator>"
+        return f"{type(self).__name__}(calculator={calc_name})"
+
     @property
     def calculator(self) -> Calculator:
         """

--- a/src/matcalc/_interface.py
+++ b/src/matcalc/_interface.py
@@ -222,22 +222,36 @@ class InterfaceCalc(PropCalc):
         matrix = interface.lattice.matrix
         area = float(np.linalg.norm(np.cross(matrix[0], matrix[1])))
 
-        unique_in_film = set(film_structure.symbol_set) - set(substrate_structure.symbol_set)
-        unique_in_substrate = set(substrate_structure.symbol_set) - set(film_structure.symbol_set)
-
-        if unique_in_film:
-            unique_element = next(iter(unique_in_film))
-            count = film_structure.composition[unique_element]
-            film_in_interface = (interface.composition[unique_element] / count) * film_structure.num_sites
-            substrate_in_interface = interface.num_sites - film_in_interface
-        elif unique_in_substrate:
-            unique_element = next(iter(unique_in_substrate))
-            count = substrate_structure.composition[unique_element]
-            substrate_in_interface = (interface.composition[unique_element] / count) * substrate_structure.num_sites
-            film_in_interface = interface.num_sites - substrate_in_interface
+        # Prefer pymatgen's per-site film/substrate indices when available
+        # (this is the only reliable signal for alloys / shared compositions).
+        film_indices = getattr(interface, "film_indices", None)
+        substrate_indices = getattr(interface, "substrate_indices", None)
+        if film_indices is not None and substrate_indices is not None:
+            film_in_interface = float(len(film_indices))
+            substrate_in_interface = float(len(substrate_indices))
         else:
-            msg = "No unique elements found in either structure to determine atom counts in interface."
-            raise ValueError(msg)
+            unique_in_film = set(film_structure.symbol_set) - set(substrate_structure.symbol_set)
+            unique_in_substrate = set(substrate_structure.symbol_set) - set(film_structure.symbol_set)
+
+            if unique_in_film:
+                unique_element = next(iter(unique_in_film))
+                count = film_structure.composition[unique_element]
+                film_in_interface = (interface.composition[unique_element] / count) * film_structure.num_sites
+                substrate_in_interface = interface.num_sites - film_in_interface
+            elif unique_in_substrate:
+                unique_element = next(iter(unique_in_substrate))
+                count = substrate_structure.composition[unique_element]
+                substrate_in_interface = (interface.composition[unique_element] / count) * substrate_structure.num_sites
+                film_in_interface = interface.num_sites - substrate_in_interface
+            else:
+                msg = (
+                    "Could not determine film vs. substrate atom counts: the interface object "
+                    "does not expose film_indices / substrate_indices and the two structures "
+                    "share their full elemental set. Pass a pymatgen Interface with film_indices "
+                    "set (built via CoherentInterfaceBuilder) or supply pre-computed energies "
+                    "via film_energy_per_atom / substrate_energy_per_atom."
+                )
+                raise ValueError(msg)
 
         gamma = (
             interface_energy

--- a/src/matcalc/_md.py
+++ b/src/matcalc/_md.py
@@ -80,6 +80,7 @@ class MDCalc(PropCalc):
         fmax: float = 0.1,
         optimizer: str = "FIRE",
         frames: int | None = None,
+        equilibration_frames: int = 0,
         relax_calc_kwargs: dict | None = None,
         set_com_stationary: bool = False,
         set_zero_rotation: bool = False,
@@ -125,8 +126,11 @@ class MDCalc(PropCalc):
             relax_structure (bool): Whether to relax the input structure before MD simulation. Default to True.
             fmax (float): Maximum force tolerance for structure relaxation (in eV/Å). Default to 0.1.
             optimizer (str): Optimizer used for structure relaxation. Default to "FIRE".
-            frames (int): Number of MD frames for analysis. Default to None, which means all frames will be
-            returned, i.e., frames = steps.
+            frames (int): Number of trailing MD frames to average energies over. Default to None,
+                which means all frames (i.e. frames = steps).
+            equilibration_frames (int): Skip this many leading frames before the trailing
+                ``frames`` window. Use this to discard non-equilibrated state at the start of an MD
+                run. Default 0.
             relax_calc_kwargs (dict | None): Additional keyword arguments for the relaxation calculation.
                 Default to None.
             set_com_stationary (bool): Whether to set the center-of-mass momentum to zero after setting up the
@@ -163,6 +167,7 @@ class MDCalc(PropCalc):
         self.fmax = fmax
         self.optimizer = optimizer
         self.frames = frames if frames is not None else self.steps
+        self.equilibration_frames = equilibration_frames
         self.relax_calc_kwargs = relax_calc_kwargs
         self.set_com_stationary = set_com_stationary
         self.set_zero_rotation = set_zero_rotation
@@ -405,14 +410,20 @@ class MDCalc(PropCalc):
 
         result["final_structure"] = to_pmg_structure(all_frames[-1])  # type: ignore[arg-type]
 
-        traj = all_frames[-self.frames :]
+        # Drop equilibration_frames from the start, then take the trailing ``frames`` window.
+        eq_skipped = all_frames[self.equilibration_frames :] if self.equilibration_frames else all_frames
+        traj = eq_skipped[-self.frames :]
+        n_avg = len(traj)
+        if n_avg == 0:
+            raise ValueError(
+                f"No frames left to average after dropping {self.equilibration_frames=} "
+                f"and taking the last {self.frames=}; got {len(all_frames)} total frames."
+            )
 
-        # Calculate the average potential energy over the selected frames.
-        energy_pot = sum(a.get_potential_energy() for a in traj) / self.frames
-        # Calculate the average kinetic energy over the selected frames.
-        energy_kin = sum(a.get_kinetic_energy() for a in traj) / self.frames
-        # Calculate the average total energy (potential + kinetic) over the selected frames.
-        energy_tot = sum(a.get_total_energy() for a in traj) / self.frames
+        # Calculate the average potential, kinetic and total energies over the selected window.
+        energy_pot = sum(a.get_potential_energy() for a in traj) / n_avg
+        energy_kin = sum(a.get_kinetic_energy() for a in traj) / n_avg
+        energy_tot = sum(a.get_total_energy() for a in traj) / n_avg
 
         # Update the result dictionary with the simulation trajectory and computed energy.
         result |= {

--- a/src/matcalc/_qha.py
+++ b/src/matcalc/_qha.py
@@ -142,7 +142,8 @@ class QHACalc(PropCalc):
         self.relax_structure = relax_structure
         self.relax_calc_kwargs = relax_calc_kwargs
         self.phonon_calc_kwargs = phonon_calc_kwargs
-        self.scale_factors = scale_factors
+        # EOS fitting downstream assumes monotonic volume ordering.
+        self.scale_factors = tuple(sorted(scale_factors))
         self.imaginary_freq_tol = imaginary_freq_tol
         self.on_imaginary_modes = on_imaginary_modes
         self.fix_imaginary_attempts = fix_imaginary_attempts
@@ -352,16 +353,22 @@ class QHACalc(PropCalc):
             )
 
             # Collect properties
+            volume = phonon_result["final_structure"].volume
+            volume_drift = np.abs(volume - scaled_structure.volume) / scaled_structure.volume
+            if volume_drift > 1e-4:  # noqa: PLR2004
+                logger.warning(
+                    "Scale factor %.3f: fixed-cell relaxation drifted volume by %.4f%% "
+                    "(expected %.4f Å³, got %.4f Å³). Skipping this scale factor; the QHA "
+                    "fit will use the remaining points. Loosen fmax or tighten the cell "
+                    "filter constraints if this happens often.",
+                    scale_factor,
+                    volume_drift * 100,
+                    scaled_structure.volume,
+                    volume,
+                )
+                continue
             ha.append(phonon_result)
             scaled_structures.append(phonon_result["final_structure"])
-            volume = phonon_result["final_structure"].volume
-            if (
-                np.abs(volume - scaled_structure.volume) / scaled_structure.volume > 1e-4  # noqa: PLR2004
-            ):
-                raise ValueError(
-                    f"Somehow the volume changed during relaxation. This is a bug! Before: {scaled_structure.volume}. "
-                    f"After: {volume}"
-                )
             volumes.append(volume)
             electronic_energies.append(phonon_result.get("energy", relaxed_result.get("energy")))
             thermal_properties = phonon_result["thermal_properties"]

--- a/src/matcalc/config.py
+++ b/src/matcalc/config.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import pathlib
 import shutil
+
+logger = logging.getLogger(__name__)
 
 BENCHMARK_HF_REPO_ID: str = "materialyze/matcalc-bench"
 BENCHMARK_DATA_DIR: pathlib.Path = pathlib.Path.home() / ".cache" / "matcalc"
@@ -27,4 +30,4 @@ def clear_cache(*, confirm: bool = True) -> None:
         try:
             shutil.rmtree(BENCHMARK_DATA_DIR)
         except FileNotFoundError:
-            print(f"matcalc cache dir {BENCHMARK_DATA_DIR} not found")  # noqa: T201
+            logger.info("matcalc cache dir %s not found", BENCHMARK_DATA_DIR)

--- a/src/matcalc/utils.py
+++ b/src/matcalc/utils.py
@@ -634,17 +634,19 @@ _PROVIDER_LOADERS: dict[str, Callable[[dict[str, Any]], Calculator]] = {
 
 def to_ase_atoms(structure: Atoms | Structure | Molecule) -> Atoms:
     """
-    Converts a given structure into an ASE Atoms object. This function checks
-    if the input structure is already an ASE Atoms object. If not, it converts
-    a pymatgen Structure object to an ASE Atoms object     using the AseAtomsAdaptor.
+    Converts a given structure into an ASE Atoms object. If the input is already
+    an ``Atoms``, a shallow copy is returned so that downstream code (which
+    routinely attaches a calculator and runs optimizers in-place) cannot mutate
+    a caller-owned object — important for parallel ``calc_many`` execution
+    where joblib workers must not share state.
 
     Args:
         structure: ASE ``Atoms``, pymatgen ``Structure``, or ``Molecule``.
 
     Returns:
-        ASE ``Atoms`` for the same system.
+        Fresh ASE ``Atoms`` for the same system.
     """
-    return structure if isinstance(structure, Atoms) else AseAtomsAdaptor.get_atoms(structure)
+    return structure.copy() if isinstance(structure, Atoms) else AseAtomsAdaptor.get_atoms(structure)
 
 
 def to_pmg_structure(structure: Atoms | Structure) -> Structure:


### PR DESCRIPTION
## Summary

Bundles small audit items into one PR — five Theme 1 correctness fixes and the remaining Theme 5 polish work, plus the Theme 3.7 mutation hazard.

### Correctness (Theme 1)
- **1.13/1.14 QHA**: `scale_factors` are sorted before fitting; the per-scale volume-drift check now warns and skips instead of crashing the whole run, so the EOS fit can still use the remaining points.
- **1.15 MD**: new `equilibration_frames` kwarg drops leading non-equilibrated frames before averaging energies. Empty averaging windows raise a clear `ValueError` instead of dividing by zero.
- **1.16 InterfaceCalc**: prefers pymatgen's `Interface.film_indices` / `substrate_indices` to count film vs substrate atoms; the old unique-element heuristic is kept as a fallback. Alloys / shared compositions no longer crash, and the error message tells the user how to recover.
- **1.18 AdsorptionCalc**: replace hardcoded 15 Å adsorbate vacuum with an `adsorbate_vacuum_size` constructor kwarg.

### Polish (Theme 5 + 3.7)
- **5.6** `PropCalc.__repr__` for ergonomic logging / `repr()` output.
- **3.7** `to_ase_atoms()` now always returns a copy. Closes a footgun where joblib workers shared and mutated the same `Atoms` object.
- **5.8** `config.clear_cache` replaces `print()` with module-level logger.
- **5.9** `__init__.py` declares `__all__` and attaches a `NullHandler` to the matcalc logger (standard library convention).

### Skipped from Theme 5
- **5.7** "Standardize `logger = logging.getLogger(__name__)` per module" — added only to `config.py` where logging is now used. Adding it to every module would be dead code in files that never log.
- **5.4** Runtime backend selection / **5.5** MSONable — deferred; non-trivial.

## Test plan
- [x] `ruff check src tests`, `ruff format --check`, `mypy -p matcalc` clean
- [x] `pytest tests --ignore=tests/test_lammps.py` — 106 passed, 38 skipped
- [ ] CI matrix (matgl / mace / grace) still loads cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)