### PR TITLE
Fix unit docstring for `gibbs_free_energies`

### DIFF
--- a/src/matcalc/_qha.py
+++ b/src/matcalc/_qha.py
@@ -213,7 +213,7 @@ class QHACalc(PropCalc):
             ``electronic_energies`` in eV, ``scaled_structures``), a ``pressures`` list (GPa),
             ``temperatures`` (K), and a ``qha_results`` list of per-pressure dicts each
             containing ``pressure`` (GPa), ``qha`` (``PhonopyQHA``),
-            ``thermal_expansion_coefficients`` (1/K), ``gibbs_free_energies`` (kJ/mol),
+            ``thermal_expansion_coefficients`` (1/K), ``gibbs_free_energies`` (eV),
             ``bulk_modulus_P`` (GPa), ``heat_capacity_P`` (J/(K*mol)), and
             ``gruneisen_parameters`` (dimensionless). When only a single pressure was
             requested the top-level dict also contains those keys directly for backward
@@ -296,7 +296,7 @@ class QHACalc(PropCalc):
             "volumes": "A^3",
             "electronic_energies": "eV",
             "thermal_expansion_coefficients": "1/K",
-            "gibbs_free_energies": "kJ/mol",
+            "gibbs_free_energies": "eV",
             "bulk_modulus_P": "GPa",
             "heat_capacity_P": "J/(K*mol)",
             "gruneisen_parameters": "dimensionless",

--- a/tests/test_qha.py
+++ b/tests/test_qha.py
@@ -135,7 +135,7 @@ def test_qha_calc(
     assert units["volumes"] == "A^3"
     assert units["electronic_energies"] == "eV"
     assert units["thermal_expansion_coefficients"] == "1/K"
-    assert units["gibbs_free_energies"] == "kJ/mol"
+    assert units["gibbs_free_energies"] == "eV"
     assert units["bulk_modulus_P"] == "GPa"
     assert units["heat_capacity_P"] == "J/(K*mol)"
     assert units["gruneisen_parameters"] == "dimensionless"


### PR DESCRIPTION
The units for Gibbs free energies in `QHACalc` are labeled as kJ/mol, but they should be in eV as noted [here](https://phonopy.github.io/phonopy/qha.html#output-files).
